### PR TITLE
fix: add test for block rm

### DIFF
--- a/js/src/block/index.js
+++ b/js/src/block/index.js
@@ -4,6 +4,7 @@ const { createSuite } = require('../utils/suite')
 const tests = {
   put: require('./put'),
   get: require('./get'),
+  rm: require('./rm'),
   stat: require('./stat')
 }
 

--- a/js/src/block/rm.js
+++ b/js/src/block/rm.js
@@ -1,0 +1,54 @@
+/* eslint-env mocha */
+'use strict'
+
+const CID = require('cids')
+const auto = require('async/auto')
+const { getDescribe, getIt, expect } = require('../utils/mocha')
+
+module.exports = (createCommon, options) => {
+  const describe = getDescribe(options)
+  const it = getIt(options)
+  const common = createCommon()
+
+  describe('.block.rm', function () {
+    const data = Buffer.from('blorb')
+    let ipfs, hash
+
+    before(function (done) {
+      // CI takes longer to instantiate the daemon, so we need to increase the
+      // timeout for the before step
+      this.timeout(60 * 1000)
+
+      auto({
+        factory: (cb) => common.setup(cb),
+        ipfs: ['factory', (res, cb) => res.factory.spawnNode(cb)],
+        block: ['ipfs', (res, cb) => res.ipfs.block.put(data, cb)]
+      }, (err, res) => {
+        if (err) return done(err)
+        ipfs = res.ipfs
+        hash = res.block.cid.multihash
+        done()
+      })
+    })
+
+    after((done) => common.teardown(done))
+
+    it('should remove by CID object', (done) => {
+      const cid = new CID(hash)
+      ipfs.block.rm(cid, (err) => {
+        expect(err).to.not.exist()
+        done()
+      })
+    })
+
+    it('should error on removing non-existent block', (done) => {
+      const cid = new CID('QmYi5NFboBxXvdoRDSa7LaLcQvCukULCaDbZKXUXz4umPa')
+      ipfs.block.rm(cid, (err, block) => {
+        expect(err).to.exist()
+        done()
+      })
+    })
+
+    // TODO it.skip('Promises support', (done) => {})
+  })
+}


### PR DESCRIPTION
Sadly those tests can't be enabled yet as js-ipfs-api doesn't implement `block/rm` yet (see https://github.com/ipfs/js-ipfs-api/issues/792).

But I thought I make a pull request with the test though, so that work doesn't get wasted.