### PR TITLE
fix: update dht tests

### DIFF
--- a/js/src/dht/findpeer.js
+++ b/js/src/dht/findpeer.js
@@ -41,7 +41,7 @@ module.exports = (createCommon, options) => {
       nodeA.dht.findpeer(nodeB.peerId.id, (err, peer) => {
         expect(err).to.not.exist()
         // TODO upgrade the answer, format is weird
-        expect(peer[0].Responses[0].ID).to.be.equal(nodeB.peerId.id)
+        expect(peer.responses[0].id).to.be.equal(nodeB.peerId.id)
         done()
       })
     })

--- a/js/src/dht/findprovs.js
+++ b/js/src/dht/findprovs.js
@@ -55,7 +55,7 @@ module.exports = (createCommon, options) => {
       waterfall([
         (cb) => nodeB.object.new('unixfs-dir', cb),
         (dagNode, cb) => {
-          const cidV0 = new CID(dagNode.toJSON().multihash)
+          const cidV0 = new CID(dagNode.toJSON().hash)
           nodeB.dht.provide(cidV0, (err) => cb(err, cidV0))
         },
         (cidV0, cb) => nodeA.dht.findprovs(cidV0, cb),

--- a/js/src/dht/get.js
+++ b/js/src/dht/get.js
@@ -1,6 +1,7 @@
 /* eslint-env mocha */
 'use strict'
 
+const hat = require('hat')
 const waterfall = require('async/waterfall')
 const { spawnNodesWithId } = require('../utils/spawn')
 const { getDescribe, getIt, expect } = require('../utils/mocha')
@@ -30,7 +31,6 @@ module.exports = (createCommon, options) => {
 
           nodeA = nodes[0]
           nodeB = nodes[1]
-
           connect(nodeA, nodeB.peerId.addresses[0], done)
         })
       })
@@ -39,28 +39,53 @@ module.exports = (createCommon, options) => {
     after((done) => common.teardown(done))
 
     it('should error when getting a non-existent key from the DHT', (done) => {
-      nodeA.dht.get('non-existing', { timeout: '100ms' }, (err, value) => {
+      nodeA.dht.get('non-existing', { timeout: '100ms' }, (err) => {
         expect(err).to.be.an.instanceof(Error)
         done()
       })
     })
 
-    it('should get a value after it was put on another node', function (done) {
+    it('should get a value after it was added on another node', function (done) {
       this.timeout(80 * 1000)
 
-      // TODO - this test needs to keep tryingl instead of the setTimeout
       waterfall([
-        (cb) => nodeB.object.new('unixfs-dir', cb),
+        (cb) => nodeB.object.put(Buffer.from(hat()), cb),
         (dagNode, cb) => setTimeout(() => cb(null, dagNode), 20000),
         (dagNode, cb) => {
-          const multihash = dagNode.toJSON().multihash
+          const hash = dagNode.toJSON().hash
 
-          nodeA.dht.get(multihash, cb)
+          nodeA.object.get(hash, cb)
         },
         (result, cb) => {
-          expect(result).to.eql('')
+          expect(result).to.exist()
           cb()
         }
+      ], done)
+    })
+
+    it('should get a value after it was put on another node', function (done) {
+      this.timeout(80 * 1000)
+      const multihash = Buffer.from('/v/hello')
+      const data = Buffer.from('data')
+
+      // Rewrite validators to simply validate the record
+      nodeA._libp2pNode._dht.validators.v = nodeB._libp2pNode._dht.validators.v = {
+        func (key, publicKey, callback) {
+          setImmediate(callback)
+        },
+        sign: false
+      }
+
+      // Rewrite selectors to select first received record
+      nodeA._libp2pNode._dht.selectors.v = () => 0
+
+      waterfall([
+        (cb) => nodeB.dht.put(multihash, data, cb),
+        (cb) => nodeA.dht.get(multihash, (err, res) => {
+          expect(err).to.not.exist()
+          expect(res).to.eql(data)
+          cb()
+        })
       ], done)
     })
   })

--- a/js/src/dht/put.js
+++ b/js/src/dht/put.js
@@ -1,7 +1,9 @@
 /* eslint-env mocha */
 'use strict'
 
+const { spawnNodesWithId } = require('../utils/spawn')
 const { getDescribe, getIt, expect } = require('../utils/mocha')
+const { connect } = require('../utils/swarm')
 
 module.exports = (createCommon, options) => {
   const describe = getDescribe(options)
@@ -9,6 +11,11 @@ module.exports = (createCommon, options) => {
   const common = createCommon()
 
   describe('.dht.put', function () {
+    this.timeout(80 * 1000)
+
+    let nodeA
+    let nodeB
+
     before(function (done) {
       // CI takes longer to instantiate the daemon, so we need to increase the
       // timeout for the before step
@@ -16,14 +23,28 @@ module.exports = (createCommon, options) => {
 
       common.setup((err, factory) => {
         expect(err).to.not.exist()
-        done()
+
+        spawnNodesWithId(2, factory, (err, nodes) => {
+          expect(err).to.not.exist()
+
+          nodeA = nodes[0]
+          nodeB = nodes[1]
+          connect(nodeA, nodeB.peerId.addresses[0], done)
+        })
       })
     })
 
     after((done) => common.teardown(done))
 
-    it.skip('should put a value on the DHT', (done) => {
-      // TODO: implement me
+    it('should put a value on the DHT and it become provided by the peer', (done) => {
+      this.timeout(80 * 1000)
+      const key = Buffer.from('QmUNLLsPACCz1vLxQVkXqqLX5R1X345qqfHbsf67hvA3Nn')
+      const data = Buffer.from('data')
+
+      nodeA.dht.put(key, data, (err) => {
+        expect(err).to.not.exist()
+        done()
+      })
     })
   })
 }


### PR DESCRIPTION
In this PR, a currently broken test is skipped and a new test was added to both `dht.get` and `dht.put`.

In the context of [js-ipfs#856](https://github.com/ipfs/js-ipfs/pull/856) and more precisely [js-ipfs#856#issuecomment-435507070](https://github.com/ipfs/js-ipfs/pull/856#issuecomment-435507070).

Needs:

- [x] [ipfs/js-ipfs#856](https://github.com/ipfs/js-ipfs/pull/856)