### PR TITLE
docs: remove references to Go

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ The API is presented with both Node.js and Go primitives. However, there are no 
 
 - [JavaScript IPFS implementation](https://github.com/ipfs/js-ipfs)
 - [JavaScript IPFS HTTP Client Library](https://github.com/ipfs/js-ipfs-api)
-- Soon™, go-ipfs, go-ipfs-api, java-ipfs-api, python-ipfs-api and others will implement it as well.
+- [JavaScript IPFS postMessage proxy](https://github.com/ipfs-shipyard/ipfs-postmsg-proxy)
 
 Send in a PR if you find or write one!
 
@@ -57,8 +57,6 @@ In JavaScript land:
 npm install interface-ipfs-core
 ```
 
-In Go land:
-
 If you want to run these tests against a go-ipfs daemon, checkout [ipfs-http-client](https://github.com/ipfs/js-ipfs-http-client) and run test tests:
 
 ```
@@ -68,8 +66,6 @@ npm test
 ```
 
 ## Usage
-
-### JavaScript
 
 Install `interface-ipfs-core` as one of the dependencies of your project and as a test file. Then, using `mocha` (for Node.js) or a test runner with compatible API, do:
 
@@ -156,7 +152,7 @@ tests.repo(createCommon, { only: ['should do a thing'] })
 
 ## API
 
-In order to be considered "valid", an IPFS core implementation  must expose the API described in [/SPEC](/SPEC). You can also use this loose spec as documentation for consuming the core APIs. Here is an outline of the contents of that directory:
+In order to be considered "valid", an IPFS core implementation must expose the API described in [/SPEC](/SPEC). You can also use this loose spec as documentation for consuming the core APIs. Here is an outline of the contents of that directory:
 
 - **Files**
   - [files](/SPEC/FILES.md)
@@ -166,15 +162,17 @@ In order to be considered "valid", an IPFS core implementation  must expose the 
   - [dag](/SPEC/DAG.md)
   - [object](/SPEC/OBJECT.md)
   - [pin](/SPEC/PIN.md)
+- [**Name**](/SPEC/NAME.md)
 - **Network**
   - [bootstrap](/SPEC/BOOSTRAP.md)
-  - [bitswap (not spec'ed yet)](/SPEC/BITSWAP.md)
-  - [dht (not spec'ed yet)](/SPEC/DHT.md)
+  - [bitswap](/SPEC/BITSWAP.md)
+  - [dht](/SPEC/DHT.md)
   - [pubsub](/SPEC/PUBSUB.md)
   - [swarm](/SPEC/SWARM.md)
 - **Node Management**
   - [Miscellaneous](/SPEC/MISCELLANEOUS.md)
   - [config](/SPEC/CONFIG.md)
+  - [key](/SPEC/KEY.md)
   - [stats](/SPEC/STATS.md)
   - [repo](/SPEC/REPO.md)
 - [**Types**](/SPEC/TYPES.md)

--- a/SPEC/BITSWAP.md
+++ b/SPEC/BITSWAP.md
@@ -7,9 +7,7 @@
 
 > Returns the wantlist, optionally filtered by peer ID
 
-#### Go **WIP**
-
-#### JavaScript - `ipfs.bitswap.wantlist([peerId], [callback])`
+#### `ipfs.bitswap.wantlist([peerId], [callback])`
 
 `callback` must follow `function (err, list) {}` signature, where `err` is an error if the operation was not successful. `list` is an Object containing the following keys:
 
@@ -34,9 +32,7 @@ ipfs.bitswap.wantlist(peerId, (err, list) => console.log(list))
 
 > Show diagnostic information on the bitswap agent.
 
-##### Go **WIP**
-
-##### JavaScript - `ipfs.bitswap.stat([callback])`
+##### `ipfs.bitswap.stat([callback])`
 
 Note: `bitswap.stat` and `stats.bitswap` can be used interchangeably.
 

--- a/SPEC/BLOCK.md
+++ b/SPEC/BLOCK.md
@@ -8,9 +8,7 @@
 
 > Get a raw IPFS block.
 
-##### Go **WIP**
-
-##### JavaScript - `ipfs.block.get(cid, [options], [callback])`
+##### `ipfs.block.get(cid, [options], [callback])`
 
 `cid` is a [cid][cid] which can be passed as:
 
@@ -44,9 +42,7 @@ A great source of [examples][] can be found in the tests for this API.
 
 > Stores input as an IPFS block.
 
-##### Go **WIP**
-
-##### JavaScript - `ipfs.block.put(block, [options], [callback])`
+##### `ipfs.block.put(block, [options], [callback])`
 
 Where `block` can be:
 
@@ -114,9 +110,7 @@ A great source of [examples][] can be found in the tests for this API.
 
 > Print information of a raw IPFS block.
 
-##### Go **WIP**
-
-##### JavaScript - `ipfs.block.stat(cid, [callback])`
+##### `ipfs.block.stat(cid, [callback])`
 
 `cid` is a [cid][cid] which can be passed as:
 

--- a/SPEC/BOOTSTRAP.md
+++ b/SPEC/BOOTSTRAP.md
@@ -14,9 +14,7 @@
 
 > Add a peer address to the bootstrap list
 
-##### Go **WIP**
-
-##### JavaScript - `ipfs.bootstrap.add(addr, [options], [callback])`
+##### `ipfs.bootstrap.add(addr, [options], [callback])`
 
 - `addr` is a [multiaddr](https://github.com/multiformats/js-multiaddr) to a peer node
 - `options.default` if true, add the default peers to the list
@@ -26,9 +24,7 @@
 
 > List all peer addresses in the bootstrap list
 
-##### Go **WIP**
-
-##### JavaScript - `ipfs.bootstrap.list([callback])``
+##### `ipfs.bootstrap.list([callback])``
 
 - `callback` must follow `function (err, res) {}` signature, where `err` is an error if the operation was not successful. `res.Peers` is an array of addresses.
 
@@ -37,9 +33,7 @@
 
 > Remove a peer address from the bootstrap list
 
-##### Go **WIP**
-
-##### JavaScript - `ipfs.bootstrap.rm(peer, [options], [callback])`
+##### `ipfs.bootstrap.rm(peer, [options], [callback])`
 
 - `addr` is a [multiaddr](https://github.com/multiformats/js-multiaddr) to a peer node
 - `options.all` if true, remove all peers from the list

--- a/SPEC/CONFIG.md
+++ b/SPEC/CONFIG.md
@@ -8,9 +8,7 @@
 
 > Returns the currently being used config. If the daemon is off, it returns the stored config.
 
-##### Go **WIP**
-
-##### JavaScript - `ipfs.config.get([key], [callback])`
+##### `ipfs.config.get([key], [callback])`
 
 `key` is the key of the value that should be fetched from the config file. If no key is passed, then the whole config should be returned. `key` should be of type String.
 
@@ -35,9 +33,7 @@ A great source of [examples][] can be found in the tests for this API.
 
 > Adds or replaces a config value.
 
-##### Go **WIP**
-
-##### JavaScript - `ipfs.config.set(key, value, [callback])`
+##### `ipfs.config.set(key, value, [callback])`
 
 `key` is the key value that will be added or replaced (in case of the value already). `key` should be of type String.
 
@@ -66,9 +62,7 @@ A great source of [examples][] can be found in the tests for this API.
 
 > Adds or replaces a config file.
 
-##### Go **WIP**
-
-##### JavaScript - `ipfs.config.replace(config, [callback])`
+##### `ipfs.config.replace(config, [callback])`
 
 `config` is a JSON object that contains the new config.
 

--- a/SPEC/DAG.md
+++ b/SPEC/DAG.md
@@ -10,9 +10,7 @@
 
 > Store an IPLD format node
 
-##### Go **WIP**
-
-##### JavaScript - `ipfs.dag.put(dagNode, [options], [callback])`
+##### `ipfs.dag.put(dagNode, [options], [callback])`
 
 - `dagNode` - a DAG node that follows one of the supported IPLD formats.
 - `options` - a object that might contain the following values:
@@ -46,9 +44,7 @@ A great source of [examples][] can be found in the tests for this API.
 
 > Retrieve an IPLD format node
 
-##### Go **WIP**
-
-##### JavaScript - `ipfs.dag.get(cid, [path], [options], [callback])`
+##### `ipfs.dag.get(cid, [path], [options], [callback])`
 
 - `cid` - can be one of the following:
   - a [CID](https://github.com/ipfs/js-cid) instance.
@@ -117,9 +113,7 @@ A great source of [examples][] can be found in the tests for this API.
 
 > Enumerate all the entries in a graph
 
-##### Go **WIP**
-
-##### JavaScript - `ipfs.dag.tree(cid, [path], [options], [callback])`
+##### `ipfs.dag.tree(cid, [path], [options], [callback])`
 
 - `cid` - can be one of the following:
   - a [CID](https://github.com/ipfs/js-cid) instance.

--- a/SPEC/DHT.md
+++ b/SPEC/DHT.md
@@ -11,9 +11,7 @@
 
 > Retrieve the Peer Info of a reachable node in the network.
 
-##### Go **WIP**
-
-##### JavaScript - `ipfs.dht.findPeer(peerId, [callback])`
+##### `ipfs.dht.findPeer(peerId, [callback])`
 
 Where `peerId` is a IPFS/libp2p Id from [PeerId](https://github.com/libp2p/js-peer-id) type.
 
@@ -39,9 +37,7 @@ A great source of [examples][] can be found in the tests for this API.
 
 > Retrieve the providers for content that is addressed by an hash.
 
-##### Go **WIP**
-
-##### JavaScript - `ipfs.dht.findProvs(hash, [options], [callback])`
+##### `ipfs.dht.findProvs(hash, [options], [callback])`
 
 Where `hash` is a multihash.
 
@@ -67,9 +63,7 @@ A great source of [examples][] can be found in the tests for this API.
 
 > Retrieve a value from DHT
 
-##### Go **WIP**
-
-##### JavaScript - `ipfs.dht.get(key, [callback])`
+##### `ipfs.dht.get(key, [callback])`
 
 Where `key` is a Buffer.
 
@@ -89,9 +83,7 @@ A great source of [examples][] can be found in the tests for this API.
 
 > Announce to the network that you are providing given values.
 
-##### Go **WIP**
-
-##### JavaScript - `ipfs.dht.provide(cid, [callback])`
+##### `ipfs.dht.provide(cid, [callback])`
 
 Where `cid` is a CID or array of CIDs.
 
@@ -111,9 +103,7 @@ A great source of [examples][] can be found in the tests for this API.
 
 > Store a value on the DHT
 
-##### Go **WIP**
-
-##### JavaScript - `ipfs.dht.put(key, value, [callback])`
+##### `ipfs.dht.put(key, value, [callback])`
 
 Where `key` is a Buffer and `value` is a Buffer.
 
@@ -133,9 +123,7 @@ A great source of [examples][] can be found in the tests for this API.
 
 > Queries the network for the 'closest peers' to a given key. 'closest' is defined by the rules of the underlying Peer Routing mechanism.
 
-##### Go **WIP**
-
-##### JavaScript - `ipfs.dht.query(peerId, [callback])`
+##### `ipfs.dht.query(peerId, [callback])`
 
 Where `peerId` is a IPFS/libp2p Id of type [PeerId](https://github.com/libp2p/js-peer-id).
 

--- a/SPEC/FILES.md
+++ b/SPEC/FILES.md
@@ -37,9 +37,7 @@
 
 > Add files and data to IPFS.
 
-##### Go **WIP**
-
-##### JavaScript - `ipfs.add(data, [options], [callback])`
+##### `ipfs.add(data, [options], [callback])`
 
 Where `data` may be:
 
@@ -132,9 +130,7 @@ A great source of [examples][] can be found in the tests for this API.
 
 > Add files and data to IPFS using a [Readable Stream][rs] of class Duplex.
 
-##### Go **WIP**
-
-##### JavaScript - `ipfs.addReadableStream([options])` -> [Readable Stream][rs]
+##### `ipfs.addReadableStream([options])` -> [Readable Stream][rs]
 
 Returns a Readable Stream of class Duplex, where objects can be written of the forms
 
@@ -182,9 +178,7 @@ A great source of [examples][] can be found in the tests for this API.
 
 > Add files and data to IPFS using a [Pull Stream][ps].
 
-##### Go **WIP**
-
-##### JavaScript - `ipfs.addPullStream([options])` -> [Pull Stream][ps]
+##### `ipfs.addPullStream([options])` -> [Pull Stream][ps]
 
 Returns a Pull Stream, where objects can be written of the forms
 
@@ -228,9 +222,7 @@ pull(
 
 > Add files or entire directories from the FileSystem to IPFS
 
-##### Go **WIP**
-
-##### JavaScript - `ipfs.addFromFs(path, [options], [callback])`
+##### `ipfs.addFromFs(path, [options], [callback])`
 
 Reads a file or folder from `path` on the filesystem  and adds it to IPFS.
 
@@ -263,9 +255,7 @@ ipfs.addFromFs('path/to/a/folder', { recursive: true , ignore: ['subfolder/to/ig
 
 > Add a file from a URL to IPFS
 
-##### Go **WIP**
-
-##### JavaScript - `ipfs.addFromURL(url, [callback])`
+##### `ipfs.addFromURL(url, [callback])`
 
 ```JavaScript
 ipfs.addFromURL('http://example.com/', (err, result) => {
@@ -280,9 +270,7 @@ ipfs.addFromURL('http://example.com/', (err, result) => {
 
 > Add a file from a stream to IPFS
 
-##### Go **WIP**
-
-##### JavaScript - `ipfs.addFromStream(stream, [callback])`
+##### `ipfs.addFromStream(stream, [callback])`
 
 This is very similar to `ipfs.files.add({ path:'', content: stream })`. It is like the reverse of cat.
 
@@ -299,9 +287,7 @@ ipfs.addFromStream(<readable-stream>, (err, result) => {
 
 > Returns a file addressed by a valid IPFS Path.
 
-##### Go **WIP**
-
-##### JavaScript - `ipfs.cat(ipfsPath, [options], [callback])`
+##### `ipfs.cat(ipfsPath, [options], [callback])`
 
 `ipfsPath` can be of type:
 
@@ -340,9 +326,7 @@ A great source of [examples][] can be found in the tests for this API.
 
 > Returns a [Readable Stream][rs] containing the contents of a file addressed by a valid IPFS Path.
 
-##### Go **WIP**
-
-##### JavaScript - `ipfs.catReadableStream(ipfsPath, [options])` -> [Readable Stream][rs]
+##### `ipfs.catReadableStream(ipfsPath, [options])` -> [Readable Stream][rs]
 
 `ipfsPath` can be of type:
 
@@ -373,9 +357,7 @@ A great source of [examples][] can be found in the tests for this API.
 
 > Returns a [Pull Stream][ps] containing the contents of a file addressed by a valid IPFS Path.
 
-##### Go **WIP**
-
-##### JavaScript - `ipfs.catPullStream(ipfsPath, [options])` -> [Pull Stream][rs]
+##### `ipfs.catPullStream(ipfsPath, [options])` -> [Pull Stream][rs]
 
 `ipfsPath` can be of type:
 
@@ -405,9 +387,7 @@ A great source of [examples][] can be found in the tests for this API.
 
 > Fetch a file or an entire directory tree from IPFS that is addressed by a valid IPFS Path.
 
-##### Go **WIP**
-
-##### JavaScript - `ipfs.get(ipfsPath, [callback])`
+##### `ipfs.get(ipfsPath, [callback])`
 
 ipfsPath can be of type:
 
@@ -451,9 +431,7 @@ A great source of [examples][] can be found in the tests for this API.
 
 > Fetch a file or an entire directory tree from IPFS that is addressed by a valid IPFS Path. The files will be yielded as Readable Streams.
 
-##### Go **WIP**
-
-##### JavaScript - `ipfs.getReadableStream(ipfsPath)` -> [Readable Stream][rs]
+##### `ipfs.getReadableStream(ipfsPath)` -> [Readable Stream][rs]
 
 ipfsPath can be of type:
 
@@ -499,9 +477,7 @@ A great source of [examples][] can be found in the tests for this API.
 
 > Fetch a file or an entire directory tree from IPFS that is addressed by a valid IPFS Path. The files will be yielded as Readable Streams.
 
-##### Go **WIP**
-
-##### JavaScript - `ipfs.getPullStream(ipfsPath)` -> [Pull Stream][ps]
+##### `ipfs.getPullStream(ipfsPath)` -> [Pull Stream][ps]
 
 ipfsPath can be of type:
 
@@ -550,9 +526,7 @@ A great source of [examples][] can be found in the tests for this API.
 
 > Lists a directory from IPFS that is addressed by a valid IPFS Path.
 
-##### Go **WIP**
-
-##### JavaScript - `ipfs.ls(ipfsPath, [callback])`
+##### `ipfs.ls(ipfsPath, [callback])`
 
 > **Note:** ipfs.files.ls is currently only for MFS directories. The goal is to converge both functionality.
 
@@ -599,9 +573,7 @@ A great source of [examples][] can be found in the tests for this API.
 
 > Lists a directory from IPFS that is addressed by a valid IPFS Path. The list will be yielded as Readable Streams.
 
-##### Go **WIP**
-
-##### JavaScript - `ipfs.lsReadableStream(ipfsPath)` -> [Readable Stream][rs]
+##### `ipfs.lsReadableStream(ipfsPath)` -> [Readable Stream][rs]
 
 > **Note:** ipfs.files.ls is currently only for MFS directories. The goal is to converge both functionality.
 
@@ -647,9 +619,7 @@ A great source of [examples][] can be found in the tests for this API.
 
 > Fetch a file or an entire directory tree from IPFS that is addressed by a valid IPFS Path. The files will be yielded through a Pull Stream.
 
-##### Go **WIP**
-
-##### JavaScript - `ipfs.lsPullStream(ipfsPath)` -> [Pull Stream][ps]
+##### `ipfs.lsPullStream(ipfsPath)` -> [Pull Stream][ps]
 
 > **Note:** ipfs.files.ls is currently only for MFS directories. The goal is to converge both functionality.
 
@@ -709,9 +679,7 @@ The Mutable File System (MFS) is a virtual file system on top of IPFS that expos
 
 > Copy files.
 
-##### Go **WIP**
-
-##### JavaScript - `ipfs.files.cp(...from, to, [options], [callback])`
+##### `ipfs.files.cp(...from, to, [options], [callback])`
 
 Where:
 
@@ -765,9 +733,7 @@ ipfs.files.cp('/src-file1', '/src-file2', '/dst-dir', (err) => {
 
 > Make a directory.
 
-##### Go **WIP**
-
-##### JavaScript - `ipfs.files.mkdir(path, [options], [callback])`
+##### `ipfs.files.mkdir(path, [options], [callback])`
 
 Where:
 
@@ -795,9 +761,7 @@ ipfs.files.mkdir('/my/beautiful/directory', (err) => {
 
 > Get file or directory status.
 
-##### Go **WIP**
-
-##### JavaScript - `ipfs.files.stat(path, [options], [callback])`
+##### `ipfs.files.stat(path, [options], [callback])`
 
 Where:
 
@@ -840,9 +804,7 @@ ipfs.files.stat('/file.txt', (err, stats) => {
 
 > Remove a file or directory.
 
-##### Go **WIP**
-
-##### JavaScript - `ipfs.files.rm(...paths, [options], [callback])`
+##### `ipfs.files.rm(...paths, [options], [callback])`
 
 Where:
 
@@ -882,9 +844,7 @@ ipfs.files.rm('/my/beautiful/directory', { recursive: true }, (err) => {
 
 > Read a file into a [`Buffer`][b].
 
-##### Go **WIP**
-
-##### JavaScript - `ipfs.files.read(path, [options], [callback])`
+##### `ipfs.files.read(path, [options], [callback])`
 
 Where:
 
@@ -912,9 +872,7 @@ ipfs.files.read('/hello-world', (error, buf) => {
 
 > Read a file into a [`ReadableStream`][rs].
 
-##### Go **WIP**
-
-##### JavaScript - `ipfs.files.readReadableStream(path, [options])`
+##### `ipfs.files.readReadableStream(path, [options])`
 
 Where:
 
@@ -938,9 +896,7 @@ stream.on('data', (buf) => console.log(buf.toString('utf8')))
 
 > Read a file into a [`PullStream`][ps].
 
-##### Go **WIP**
-
-##### JavaScript - `ipfs.files.readPullStream(path, [options])`
+##### `ipfs.files.readPullStream(path, [options])`
 
 Where:
 
@@ -967,9 +923,7 @@ pull(
 
 > Write to a file.
 
-##### Go **WIP**
-
-##### JavaScript - `ipfs.files.write(path, content, [options], [callback])`
+##### `ipfs.files.write(path, content, [options], [callback])`
 
 Where:
 
@@ -1004,9 +958,7 @@ ipfs.files.write('/hello-world', Buffer.from('Hello, world!'), (err) => {
 
 > Move files.
 
-##### Go **WIP**
-
-##### JavaScript - `ipfs.files.mv(...from, to, [options], [callback])`
+##### `ipfs.files.mv(...from, to, [options], [callback])`
 
 Where:
 
@@ -1057,9 +1009,7 @@ ipfs.files.mv('/src-file1', '/src-file2', '/dst-dir', (err) => {
 
 > Flush a given path's data to the disk
 
-##### Go **WIP**
-
-##### JavaScript - `ipfs.files.flush([...paths], [callback])`
+##### `ipfs.files.flush([...paths], [callback])`
 
 Where:
 
@@ -1082,9 +1032,7 @@ ipfs.files.flush('/', (err) => {
 
 > List directories in the local mutable namespace.
 
-##### Go **WIP**
-
-##### JavaScript - `ipfs.files.ls([path], [options], [callback])`
+##### `ipfs.files.ls([path], [options], [callback])`
 
 Where:
 

--- a/SPEC/KEY.md
+++ b/SPEC/KEY.md
@@ -11,9 +11,7 @@
 
 > Generate a new key
 
-##### Go **WIP**
-
-##### JavaScript - `ipfs.key.gen(name, options, [callback])`
+##### `ipfs.key.gen(name, options, [callback])`
 
 Where:
 
@@ -42,9 +40,7 @@ ipfs.key.gen('my-key', {
 
 > List all the keys
 
-##### Go **WIP**
-
-##### JavaScript - `ipfs.key.list([callback])`
+##### `ipfs.key.list([callback])`
 
 `callback` must follow `function (err, keys) {}` signature, where `err` is an Error if the operation was not successful. `keys` is an array of:
 
@@ -74,9 +70,7 @@ ipfs.key.list((err, keys) => console.log(keys))
 
 > Remove a key
 
-##### Go **WIP**
-
-##### JavaScript - `ipfs.key.rm(name, [callback])`
+##### `ipfs.key.rm(name, [callback])`
 
 Where:
 - `name` is the local name for the key
@@ -105,9 +99,7 @@ ipfs.key.rm('my-key', (err, key) => console.log(key))
 
 > Rename a key
 
-##### Go **WIP**
-
-##### JavaScript - `ipfs.key.rename(oldName, newName, [callback])`
+##### `ipfs.key.rename(oldName, newName, [callback])`
 
 Where:
 - `oldName` is the local name for the key
@@ -134,7 +126,7 @@ ipfs.key.rename('my-key', 'my-new-key', (err, key) => console.log(key))
 
 ##### Go **NYI**
 
-##### JavaScript - `ipfs.key.export(name, password, [callback])`
+##### `ipfs.key.export(name, password, [callback])`
 
 Where:
 - `name` is the local name for the key
@@ -162,7 +154,7 @@ ipfs.key.export('self', 'password', (err, pem) => console.log(pem))
 
 ##### Go **NYI**
 
-##### JavaScript - `ipfs.key.import(name, pem, password, [callback])`
+##### `ipfs.key.import(name, pem, password, [callback])`
 
 Where:
 - `name` is a local name for the key

--- a/SPEC/MISCELLANEOUS.md
+++ b/SPEC/MISCELLANEOUS.md
@@ -13,9 +13,7 @@
 
 > Returns the identity of the Peer
 
-##### Go **WIP**
-
-##### JavaScript - `ipfs.id([callback])`
+##### `ipfs.id([callback])`
 
 `callback` must follow `function (err, identity) {}` signature, where `err` is an error if the operation was not successful. `identity` is an object with the Peer identity.
 
@@ -38,9 +36,7 @@ A great source of [examples](https://github.com/ipfs/interface-ipfs-core/blob/ma
 
 > Returns the implementation version
 
-##### Go **WIP**
-
-##### JavaScript - `ipfs.version([callback])`
+##### `ipfs.version([callback])`
 
 `callback` must follow `function (err, version) {}` signature, where `err` is an error if the operation was not successful. `version` is an object with the version of the implementation, the commit and the Repo.
 
@@ -63,9 +59,7 @@ A great source of [examples](https://github.com/ipfs/interface-ipfs-core/blob/ma
 
 > Resolve DNS links
 
-##### Go **WIP**
-
-##### JavaScript - `ipfs.dns(domain, [callback])`
+##### `ipfs.dns(domain, [callback])`
 
 `callback` must follow `function (err, path) {}` signature, where `err` is an error if the operation was not successful. `path` is the IPFS path for that domain.
 
@@ -88,9 +82,7 @@ A great source of [examples](https://github.com/ipfs/interface-ipfs-core/blob/ma
 
 > Stops the IPFS node and in case of talking with an IPFS Daemon, it stops the process.
 
-##### Go **WIP**
-
-##### JavaScript - `ipfs.stop([callback])`
+##### `ipfs.stop([callback])`
 
 `callback` must follow `function (err) {}` signature, where `err` is an error if the operation was not successful.
 If no `callback` is passed, a promise is returned.
@@ -111,9 +103,7 @@ A great source of [examples](https://github.com/ipfs/interface-ipfs-core/blob/ma
 
 > Send echo request packets to IPFS hosts
 
-##### Go **WIP**
-
-##### JavaScript - `ipfs.ping(peerId, [options], [callback])`
+##### `ipfs.ping(peerId, [options], [callback])`
 
 Where:
 
@@ -158,9 +148,7 @@ A great source of [examples](https://github.com/ipfs/interface-ipfs-core/tree/ma
 
 > Stream echo request packets to IPFS hosts
 
-##### Go **WIP**
-
-##### JavaScript - `ipfs.pingPullStream(peerId, [options], [callback])`
+##### `ipfs.pingPullStream(peerId, [options], [callback])`
 
 Where:
 
@@ -203,9 +191,7 @@ A great source of [examples](https://github.com/ipfs/interface-ipfs-core/tree/ma
 
 > Stream echo request packets to IPFS hosts
 
-##### Go **WIP**
-
-##### JavaScript - `ipfs.pingReadableStream(peerId, [options], [callback])`
+##### `ipfs.pingReadableStream(peerId, [options], [callback])`
 
 Where:
 
@@ -247,9 +233,7 @@ A great source of [examples](https://github.com/ipfs/interface-ipfs-core/tree/ma
 
 There are a number of mutable name protocols that can link among themselves and into IPNS. For example IPNS references can (currently) point at an IPFS object, and DNS links can point at other DNS links, IPNS entries, or IPFS objects. This command accepts any of these identifiers and resolves them to the referenced item.
 
-##### Go **WIP**
-
-##### JavaScript - `ipfs.resolve(name, [options], [callback])`
+##### `ipfs.resolve(name, [options], [callback])`
 
 Where:
 

--- a/SPEC/NAME.md
+++ b/SPEC/NAME.md
@@ -10,9 +10,7 @@
 
 > Publish an IPNS name with a given value.
 
-##### Go **WIP**
-
-##### JavaScript - `ipfs.name.publish(value, [options], [callback])`
+##### `ipfs.name.publish(value, [options], [callback])`
 
 `value` is a base58 encoded IPFS multihash, such as: `/ipfs/QmbezGequPwcsWo8UL4wDF6a8hYwM1hmbzYv2mnKkEWaUp`.
 
@@ -62,9 +60,7 @@ This way, you can republish a new version of your website under the same address
 
 > Cancel a name subscription.
 
-##### Go **WIP**
-
-##### JavaScript - `ipfs.name.pubsub.cancel(arg, [callback])`
+##### `ipfs.name.pubsub.cancel(arg, [callback])`
 
 `arg` is the name of the subscription to cancel.
 
@@ -93,9 +89,7 @@ ipfs.name.pubsub.cancel(name, function (err, result) {
 
 > Query the state of IPNS pubsub.
 
-##### Go **WIP**
-
-##### JavaScript - `ipfs.name.pubsub.state([callback])`
+##### `ipfs.name.pubsub.state([callback])`
 
 `callback` must follow `function (err, result) {}` signature, where `err` is an error if the operation was not successful. `result` is an object that contains the result of the operation, such as:
 
@@ -120,9 +114,7 @@ ipfs.name.pubsub.state(function (err, result) {
 
 > Show current name subscriptions.
 
-##### Go **WIP**
-
-##### JavaScript - `ipfs.name.pubsub.subs([callback])`
+##### `ipfs.name.pubsub.subs([callback])`
 
 `callback` must follow `function (err, result) {}` signature, where `err` is an error if the operation was not successful. `result` is an array of subscriptions, such as:
 
@@ -145,9 +137,7 @@ ipfs.name.pubsub.subs(function (err, result) {
 
 > Resolve an IPNS name.
 
-##### Go **WIP**
-
-##### JavaScript - `ipfs.name.resolve(value, [options], [callback])`
+##### `ipfs.name.resolve(value, [options], [callback])`
 
 `value` is a IPNS address, such as: `/ipns/ipfs.io`.
 

--- a/SPEC/OBJECT.md
+++ b/SPEC/OBJECT.md
@@ -15,9 +15,7 @@
 
 > Create a new MerkleDAG node, using a specific layout. Caveat: So far, only UnixFS object layouts are supported.
 
-##### Go **WIP**
-
-##### JavaScript - `ipfs.object.new([template], [callback])`
+##### `ipfs.object.new([template], [callback])`
 
 `template` if defined, must be a string `unixfs-dir` and if that is passed, the created node will be an empty unixfs style directory.
 
@@ -44,9 +42,7 @@ A great source of [examples][] can be found in the tests for this API.
 
 > Store an MerkleDAG node.
 
-##### Go **WIP**
-
-##### JavaScript - `ipfs.object.put(obj, [options], [callback])`
+##### `ipfs.object.put(obj, [options], [callback])`
 
 `obj` is the MerkleDAG Node to be stored. Can of type:
 
@@ -86,9 +82,7 @@ A great source of [examples][] can be found in the tests for this API.
 
 > Fetch a MerkleDAG node
 
-##### Go **WIP**
-
-##### JavaScript - `ipfs.object.get(multihash, [options], [callback])`
+##### `ipfs.object.get(multihash, [options], [callback])`
 
 `multihash` is a [multihash][] which can be passed as:
 
@@ -124,9 +118,7 @@ A great source of [examples][] can be found in the tests for this API.
 
 > Returns the Data field of an object
 
-##### Go **WIP**
-
-##### JavaScript - `ipfs.object.data(multihash, [options], [callback])`
+##### `ipfs.object.data(multihash, [options], [callback])`
 `multihash` is a [multihash][] which can be passed as:
 
 - Buffer, the raw Buffer of the multihash (or of and encoded version)
@@ -161,9 +153,7 @@ A great source of [examples][] can be found in the tests for this API.
 
 > Returns the Links field of an object
 
-##### Go **WIP**
-
-##### JavaScript - `ipfs.object.links(multihash, [options], [callback])`
+##### `ipfs.object.links(multihash, [options], [callback])`
 
 `multihash` is a [multihash][] which can be passed as:
 
@@ -199,9 +189,7 @@ A great source of [examples][] can be found in the tests for this API.
 
 > Returns stats about an Object
 
-##### Go **WIP**
-
-##### JavaScript - `ipfs.object.stat(multihash, [options], [callback])`
+##### `ipfs.object.stat(multihash, [options], [callback])`
 
 `multihash` is a [multihash][] which can be passed as:
 
@@ -259,9 +247,7 @@ A great source of [examples][] can be found in the tests for this API.
 
 > Add a Link to an existing MerkleDAG Object
 
-###### Go **WIP**
-
-###### JavaScript - `ipfs.object.patch.addLink(multihash, link, [options], [callback])`
+###### `ipfs.object.patch.addLink(multihash, link, [options], [callback])`
 
 `multihash` is a [multihash][] which can be passed as:
 
@@ -315,9 +301,7 @@ A great source of [examples][] can be found in the tests for this API.
 
 > Remove a Link from an existing MerkleDAG Object
 
-###### Go **WIP**
-
-###### JavaScript - `ipfs.object.patch.rmLink(multihash, link, [options], [callback])`
+###### `ipfs.object.patch.rmLink(multihash, link, [options], [callback])`
 
 `multihash` is a [multihash][] which can be passed as:
 
@@ -359,9 +343,7 @@ A great source of [examples][] can be found in the tests for this API.
 
 > Append Data to the Data field of an existing node.
 
-###### Go **WIP**
-
-###### JavaScript - `ipfs.object.patch.appendData(multihash, data, [options], [callback])`
+###### `ipfs.object.patch.appendData(multihash, data, [options], [callback])`
 
 `multihash` is a [multihash][] which can be passed as:
 
@@ -394,9 +376,7 @@ A great source of [examples][] can be found in the tests for this API.
 
 > Reset the Data field of a MerkleDAG Node to new Data
 
-###### Go **WIP**
-
-###### JavaScript - `ipfs.object.patch.setData(multihash, data, [options], [callback])`
+###### `ipfs.object.patch.setData(multihash, data, [options], [callback])`
 
 `multihash` is a [multihash][] which can be passed as:
 

--- a/SPEC/PIN.md
+++ b/SPEC/PIN.md
@@ -8,9 +8,7 @@
 
 > Adds an IPFS object to the pinset and also stores it to the IPFS repo. pinset is the set of hashes currently pinned (not gc'able).
 
-##### Go **WIP**
-
-##### JavaScript - `ipfs.pin.add(hash, [options], [callback])`
+##### `ipfs.pin.add(hash, [options], [callback])`
 
 Where:
 
@@ -38,9 +36,7 @@ ipfs.pin.add(hash, function (err) {})
 
 > List all the objects pinned to local storage or under a specific hash.
 
-##### Go **WIP**
-
-##### JavaScript - `ipfs.pin.ls([hash], [options], [callback])`
+##### `ipfs.pin.ls([hash], [options], [callback])`
 
 Where:
 
@@ -69,9 +65,7 @@ A great source of [examples][] can be found in the tests for this API.
 
 > Remove a hash from the pinset
 
-##### Go **WIP**
-
-##### JavaScript - `ipfs.pin.rm(hash, [options], [callback])`
+##### `ipfs.pin.rm(hash, [options], [callback])`
 
 Where:
 - `hash` is a multihash.

--- a/SPEC/PUBSUB.md
+++ b/SPEC/PUBSUB.md
@@ -10,9 +10,7 @@
 
 > Subscribe to a pubsub topic.
 
-##### Go **WIP**
-
-##### JavaScript - `ipfs.pubsub.subscribe(topic, handler, [options], [callback])`
+##### `ipfs.pubsub.subscribe(topic, handler, [options], [callback])`
 
 - `topic: String`
 - `handler: (msg) => {}` - Event handler which will be called with a message object everytime one is received. The `msg` has the format `{from: String, seqno: Buffer, data: Buffer, topicIDs: Array<String>}`.
@@ -44,9 +42,7 @@ A great source of [examples][] can be found in the tests for this API.
 
 > Unsubscribes from a pubsub topic.
 
-##### Go **WIP**
-
-##### JavaScript - `ipfs.pubsub.unsubscribe(topic, handler, [callback])`
+##### `ipfs.pubsub.unsubscribe(topic, handler, [callback])`
 
 - `topic: String` - The topic to unsubscribe from
 - `handler: (msg) => {}` - The handler to remove.
@@ -88,9 +84,7 @@ A great source of [examples][] can be found in the tests for this API.
 
 > Publish a data message to a pubsub topic.
 
-##### Go **WIP**
-
-##### JavaScript - `ipfs.pubsub.publish(topic, data, [callback])`
+##### `ipfs.pubsub.publish(topic, data, [callback])`
 
 - `topic: String`
 - `data: Buffer` - The message to send
@@ -119,9 +113,7 @@ A great source of [examples][] can be found in the tests for this API.
 
 > Returns the list of subscriptions the peer is subscribed to.
 
-##### Go **WIP**
-
-##### JavaScript - `ipfs.pubsub.ls([callback])`
+##### `ipfs.pubsub.ls([callback])`
 
 - `callback: (Error, Array<string>) => {}` - (Optional) Calls back with an error or a list of topicIDs that this peer is subscribed to.
 
@@ -144,9 +136,7 @@ A great source of [examples][] can be found in the tests for this API.
 
 > Returns the peers that are subscribed to one topic.
 
-##### Go **WIP**
-
-##### JavaScript - `ipfs.pubsub.peers(topic, [callback])`
+##### `ipfs.pubsub.peers(topic, [callback])`
 
 - `topic: String`
 - `callback: (Error, Array<String>) => {}` - (Optional) Calls back with an error or a list of peer IDs subscribed to the `topic`.

--- a/SPEC/REPO.md
+++ b/SPEC/REPO.md
@@ -8,9 +8,7 @@
 
 > Perform a garbage collection sweep on the repo.
 
-##### Go **WIP**
-
-##### JavaScript - `ipfs.repo.gc([options], [callback])`
+##### `ipfs.repo.gc([options], [callback])`
 
 Where:
 
@@ -32,9 +30,7 @@ ipfs.repo.gc((err, res) => console.log(res))
 
 > Get stats for the currently used repo.
 
-##### Go **WIP**
-
-##### JavaScript - `ipfs.repo.stat([options], [callback])`
+##### `ipfs.repo.stat([options], [callback])`
 
 `stats.repo` and `repo.stat` can be used interchangeably.
 
@@ -69,9 +65,7 @@ ipfs.repo.stat((err, stats) => console.log(stats))
 
 > Show the repo version.
 
-##### Go **WIP**
-
-##### JavaScript - `ipfs.repo.version([callback])`
+##### `ipfs.repo.version([callback])`
 
 `callback` must follow `function (err, version) {}` signature, where `err` is an Error if the operation was not successful and `version` is a String containing the version.
 

--- a/SPEC/STATS.md
+++ b/SPEC/STATS.md
@@ -22,9 +22,7 @@ Note: `stats.repo` and `repo.stat` can be used interchangeably. See [`repo.stat`
 
 > Get IPFS bandwidth information as an object.
 
-##### Go **WIP**
-
-##### JavaScript - `ipfs.stats.bw([options], [callback])`
+##### `ipfs.stats.bw([options], [callback])`
 
 Where:
 
@@ -60,9 +58,7 @@ ipfs.stats.bw((err, stats) => console.log(stats))
 
 > Get IPFS bandwidth information as a [Pull Stream][ps].
 
-##### Go **WIP**
-
-##### JavaScript - `ipfs.stats.bwPullStream([options])` -> [Pull Stream][ps]
+##### `ipfs.stats.bwPullStream([options])` -> [Pull Stream][ps]
 
 Options are described on [`ipfs.stats.bw`](#bw).
 
@@ -91,9 +87,7 @@ pull(
 
 > Get IPFS bandwidth information as a [Readable Stream][rs].
 
-##### Go **WIP**
-
-##### JavaScript - `ipfs.stats.bwReadableStream([options])` -> [Readable Stream][rs]
+##### `ipfs.stats.bwReadableStream([options])` -> [Readable Stream][rs]
 
 Options are described on [`ipfs.stats.bw`](#bw).
 

--- a/SPEC/SWARM.md
+++ b/SPEC/SWARM.md
@@ -11,9 +11,7 @@
 
 > List of known addresses of each peer connected.
 
-##### Go **WIP**
-
-##### JavaScript - `ipfs.swarm.addrs([callback])`
+##### `ipfs.swarm.addrs([callback])`
 
 `callback` must follow `function (err, addrs) {}` signature, where `err` is an error if the operation was not successful. `addrs` will be an array of [`PeerInfo`](https://github.com/libp2p/js-peer-info)s.
 
@@ -36,9 +34,7 @@ A great source of [examples][] can be found in the tests for this API.
 
 > Open a connection to a given address.
 
-##### Go **WIP**
-
-##### JavaScript - `ipfs.swarm.connect(addr, [callback])`
+##### `ipfs.swarm.connect(addr, [callback])`
 
 Where `addr` is of type [multiaddr](https://github.com/multiformats/js-multiaddr)
 
@@ -63,9 +59,7 @@ A great source of [examples][] can be found in the tests for this API.
 
 > Close a connection on a given address.
 
-##### Go **WIP**
-
-##### JavaScript - `ipfs.swarm.disconnect(addr, [callback])`
+##### `ipfs.swarm.disconnect(addr, [callback])`
 
 Where `addr` is of type [multiaddr](https://github.com/multiformats/js-multiaddr)
 
@@ -85,9 +79,7 @@ A great source of [examples][] can be found in the tests for this API.
 
 > List out the peers that we have connections with.
 
-##### Go **WIP**
-
-##### JavaScript - `ipfs.swarm.peers([options], [callback])`
+##### `ipfs.swarm.peers([options], [callback])`
 
 If `options.verbose` is set to `true` additional information, such as `latency` is provided.
 
@@ -132,9 +124,7 @@ A great source of [examples][] can be found in the tests for this API.
 
 > Display current multiaddr filters. Filters are a way to set up rules for the network connections established.
 
-##### Go **WIP**
-
-##### JavaScript - `ipfs.swarm.filters([callback])`
+##### `ipfs.swarm.filters([callback])`
 
 `callback` must follow `function (err, filters) {}` signature, where `err` is an error if the operation was not successful. `filters` is an array of multiaddrs that represent the filters being applied.
 
@@ -150,9 +140,7 @@ ipfs.swarm.filters(function (err, filters) {})
 
 > Add another filter.
 
-##### Go **WIP**
-
-##### JavaScript - `ipfs.swarm.filters.add(filter, [callback])`
+##### `ipfs.swarm.filters.add(filter, [callback])`
 
 Where `filter` is of type [multiaddr]()
 
@@ -170,9 +158,7 @@ ipfs.swarm.filters.add(filter, function (err) {})
 
 > Remove a filter
 
-##### Go **WIP**
-
-##### JavaScript - `ipfs.swarm.filters.rm(filter, [callback])`
+##### `ipfs.swarm.filters.rm(filter, [callback])`
 
 Where `filter` is of type [multiaddr]()
 


### PR DESCRIPTION
Tidy up the API docs by removing refs to Go as well as JavaScript (since this is the JS interface repo).

refs https://github.com/ipfs/interface-js-ipfs-core/issues/423
refs https://github.com/ipfs/interface-js-ipfs-core/pull/435