### PR TITLE
fix: populate in series

### DIFF
--- a/src/pin/ls.js
+++ b/src/pin/ls.js
@@ -1,7 +1,7 @@
 /* eslint-env mocha */
 'use strict'
 
-const parallel = require('async/parallel')
+const series = require('async/series')
 const { fixtures } = require('./utils')
 const { getDescribe, getIt, expect } = require('../utils/mocha')
 
@@ -30,19 +30,11 @@ module.exports = (createCommon, options) => {
       })
 
       function populate () {
-        parallel([
-          (cb) => {
-            ipfs.add(fixtures.files[0].data, { pin: false }, (err, res) => {
-              if (err) return cb(err)
-              ipfs.pin.add(fixtures.files[0].cid, { recursive: true }, cb)
-            })
-          },
-          (cb) => {
-            ipfs.add(fixtures.files[1].data, { pin: false }, (err, res) => {
-              if (err) return cb(err)
-              ipfs.pin.add(fixtures.files[1].cid, { recursive: false }, cb)
-            })
-          }
+        series([
+          cb => ipfs.add(fixtures.files[0].data, { pin: false }, cb),
+          cb => ipfs.pin.add(fixtures.files[0].cid, { recursive: true }, cb),
+          cb => ipfs.add(fixtures.files[1].data, { pin: false }, cb),
+          cb => ipfs.pin.add(fixtures.files[1].cid, { recursive: false }, cb)
         ], done)
       }
     })

--- a/src/pin/rm.js
+++ b/src/pin/rm.js
@@ -1,7 +1,7 @@
 /* eslint-env mocha */
 'use strict'
 
-const parallel = require('async/parallel')
+const series = require('async/series')
 const { fixtures } = require('./utils')
 const { getDescribe, getIt, expect } = require('../utils/mocha')
 
@@ -30,19 +30,11 @@ module.exports = (createCommon, options) => {
       })
 
       function populate () {
-        parallel([
-          (cb) => {
-            ipfs.add(fixtures.files[0].data, { pin: false }, (err, res) => {
-              if (err) return cb(err)
-              ipfs.pin.add(fixtures.files[0].cid, { recursive: true }, cb)
-            })
-          },
-          (cb) => {
-            ipfs.add(fixtures.files[1].data, { pin: false }, (err, res) => {
-              if (err) return cb(err)
-              ipfs.pin.add(fixtures.files[1].cid, { recursive: false }, cb)
-            })
-          }
+        series([
+          cb => ipfs.add(fixtures.files[0].data, { pin: false }, cb),
+          cb => ipfs.pin.add(fixtures.files[0].cid, { recursive: true }, cb),
+          cb => ipfs.add(fixtures.files[1].data, { pin: false }, cb),
+          cb => ipfs.pin.add(fixtures.files[1].cid, { recursive: false }, cb)
         ], done)
       }
     })


### PR DESCRIPTION
Potential temporary fix for:

```
Error: EPERM: operation not permitted, rename 'C:\Users\travis\AppData\Local\Temp\ipfs-test-de2fc17f2aa28095e191f466fe8a6601\blocks\US\.3752.7204' -> 'C:\Users\travis\AppData\Local\Temp\ipfs-test-de2fc17f2aa28095e191f466fe8a6601\blocks\US\CIQPEUFLMK4TATXY3U6F7FNH33MIRA4KTFDAKY5ZKL7CCVQDQRIZUSQ.data'
```

This happens on the windows build in js-ipfs. Perhaps concurrent read/write is the issue?