### PR TITLE
fix: swarm addrs test

### DIFF
--- a/SPEC/SWARM.md
+++ b/SPEC/SWARM.md
@@ -13,18 +13,18 @@
 
 ##### `ipfs.swarm.addrs([callback])`
 
-`callback` must follow `function (err, addrs) {}` signature, where `err` is an error if the operation was not successful. `addrs` will be an array of [`PeerInfo`](https://github.com/libp2p/js-peer-info)s.
+`callback` must follow `function (err, peerInfos) {}` signature, where `err` is an error if the operation was not successful. `peerInfos` will be an array of [`PeerInfo`](https://github.com/libp2p/js-peer-info)s.
 
 If no `callback` is passed, a promise is returned.
 
 **Example:**
 
 ```JavaScript
-ipfs.swarm.addrs(function (err, addrs) {
+ipfs.swarm.addrs(function (err, peerInfos) {
   if (err) {
     throw err
   }
-  console.log(addrs)
+  console.log(peerInfos)
 })
 ```
 

--- a/src/swarm/addrs.js
+++ b/src/swarm/addrs.js
@@ -1,7 +1,9 @@
 /* eslint-env mocha */
 'use strict'
 
+const PeerInfo = require('peer-info')
 const { getDescribe, getIt, expect } = require('../utils/mocha')
+const { spawnNodesWithId } = require('../utils/spawn')
 
 module.exports = (createCommon, options) => {
   const describe = getDescribe(options)
@@ -11,7 +13,7 @@ module.exports = (createCommon, options) => {
   describe('.swarm.addrs', function () {
     this.timeout(80 * 1000)
 
-    let ipfs
+    let ipfsA, ipfsB
 
     before(function (done) {
       // CI takes longer to instantiate the daemon, so we need to increase the
@@ -20,10 +22,12 @@ module.exports = (createCommon, options) => {
 
       common.setup((err, factory) => {
         expect(err).to.not.exist()
-        factory.spawnNode((err, node) => {
+
+        spawnNodesWithId(2, factory, (err, nodes) => {
           expect(err).to.not.exist()
-          ipfs = node
-          done()
+          ipfsA = nodes[0]
+          ipfsB = nodes[1]
+          ipfsA.swarm.connect(ipfsB.peerId.addresses[0], done)
         })
       })
     })
@@ -31,17 +35,17 @@ module.exports = (createCommon, options) => {
     after((done) => common.teardown(done))
 
     it('should get a list of node addresses', (done) => {
-      ipfs.swarm.addrs((err, multiaddrs) => {
+      ipfsA.swarm.addrs((err, multiaddrs) => {
         expect(err).to.not.exist()
         expect(multiaddrs).to.not.be.empty()
         expect(multiaddrs).to.be.an('array')
-        expect(multiaddrs[0].constructor.name).to.be.eql('PeerInfo')
+        multiaddrs.forEach(m => expect(PeerInfo.isPeerInfo(m)).to.be.true())
         done()
       })
     })
 
     it('should get a list of node addresses (promised)', () => {
-      return ipfs.swarm.addrs().then((multiaddrs) => {
+      return ipfsA.swarm.addrs().then((multiaddrs) => {
         expect(multiaddrs).to.have.length.above(0)
       })
     })

--- a/src/swarm/addrs.js
+++ b/src/swarm/addrs.js
@@ -35,18 +35,18 @@ module.exports = (createCommon, options) => {
     after((done) => common.teardown(done))
 
     it('should get a list of node addresses', (done) => {
-      ipfsA.swarm.addrs((err, multiaddrs) => {
+      ipfsA.swarm.addrs((err, peerInfos) => {
         expect(err).to.not.exist()
-        expect(multiaddrs).to.not.be.empty()
-        expect(multiaddrs).to.be.an('array')
-        multiaddrs.forEach(m => expect(PeerInfo.isPeerInfo(m)).to.be.true())
+        expect(peerInfos).to.not.be.empty()
+        expect(peerInfos).to.be.an('array')
+        peerInfos.forEach(m => expect(PeerInfo.isPeerInfo(m)).to.be.true())
         done()
       })
     })
 
     it('should get a list of node addresses (promised)', () => {
-      return ipfsA.swarm.addrs().then((multiaddrs) => {
-        expect(multiaddrs).to.have.length.above(0)
+      return ipfsA.swarm.addrs().then((peerInfos) => {
+        expect(peerInfos).to.have.length.above(0)
       })
     })
   })


### PR DESCRIPTION
If the common factory creates a node with no bootstrap nodes then getting a list of swarm addresses could be empty (or could also be empty anyway if the connection to the bootstrap nodes takes a long time). This PR spawns and connects another IPFS node to ensure that there should be swarm addresses available.