### PR TITLE
test: add test for config set with number

### DIFF
--- a/src/config/set.js
+++ b/src/config/set.js
@@ -59,6 +59,19 @@ module.exports = (createCommon, options) => {
       })
     })
 
+    it('should set a number', (done) => {
+      const key = 'Discovery.MDNS.Interval'
+      const val = 11
+      ipfs.config.set(key, val, function (err) {
+        expect(err).to.not.exist()
+        ipfs.config.get(key, function (err, result) {
+          expect(err).to.not.exist()
+          expect(result).to.equal(val)
+          done()
+        })
+      })
+    })
+
     it('should set a JSON object', (done) => {
       const key = 'API.HTTPHeaders.Access-Control-Allow-Origin'
       const val = ['http://example.io']


### PR DESCRIPTION
Anything that isn't a string needs to be passed with `--json` to the config set HTTP API. This PR tests that this is happening by virtue of setting a non string value.