### PR TITLE
fix: wait for one key to be the required key not all

### DIFF
--- a/src/bitswap/utils.js
+++ b/src/bitswap/utils.js
@@ -17,7 +17,13 @@ function waitForWantlistKey (ipfs, key, opts, cb) {
   setTimeout(() => { timedOut = true }, opts.timeout)
 
   const test = () => timedOut ? true : list.Keys.some(k => k['/'] === key)
-  const iteratee = (cb) => ipfs.bitswap.wantlist(opts.peerId, cb)
+  const iteratee = (cb) => {
+    ipfs.bitswap.wantlist(opts.peerId, (err, nextList) => {
+      if (err) return cb(err)
+      list = nextList
+      cb()
+    })
+  }
 
   until(test, iteratee, (err) => {
     if (err) return cb(err)

--- a/src/bitswap/utils.js
+++ b/src/bitswap/utils.js
@@ -16,7 +16,7 @@ function waitForWantlistKey (ipfs, key, opts, cb) {
 
   setTimeout(() => { timedOut = true }, opts.timeout)
 
-  const test = () => timedOut ? true : list.Keys.every(k => k['/'] === key)
+  const test = () => timedOut ? true : list.Keys.some(k => k['/'] === key)
   const iteratee = (cb) => ipfs.bitswap.wantlist(opts.peerId, cb)
 
   until(test, iteratee, (err) => {


### PR DESCRIPTION
Also, every returns true if there's no items in the list so this was returning a false positive.