### PR TITLE
Add links to ProtoSchool DAG API tutorials

### DIFF
--- a/SPEC/DAG.md
+++ b/SPEC/DAG.md
@@ -6,6 +6,10 @@
 * [dag.get](#dagget)
 * [dag.tree](#dagtree)
 
+_Explore the DAG API through interactive coding challenges in our ProtoSchool tutorials:_
+- _[P2P data links with content addressing](https://proto.school/#/basics/) (beginner)_
+- _[Blogging on the Decentralized Web](https://proto.school/#/blog/) (intermediate)_
+
 #### `dag.put`
 
 > Store an IPLD format node


### PR DESCRIPTION
Add links from existing docs to ProtoSchool tutorials as part of our Q3 IPFS Docs effort. See issue: https://github.com/ProtoSchool/protoschool.github.io/issues/260