### PR TITLE
fix: use the correct option name for files.ls long

### DIFF
--- a/src/files-mfs/ls-pull-stream.js
+++ b/src/files-mfs/ls-pull-stream.js
@@ -71,7 +71,7 @@ module.exports = (createCommon, options) => {
       })
     })
 
-    it('should ls -l directory', (done) => {
+    it('should ls directory with long option', (done) => {
       const testDir = `/test-${hat()}`
 
       series([
@@ -81,7 +81,7 @@ module.exports = (createCommon, options) => {
         expect(err).to.not.exist()
 
         pull(
-          ipfs.files.lsPullStream(testDir, { l: true }),
+          ipfs.files.lsPullStream(testDir, { long: true }),
           collect((err, entries) => {
             expect(err).to.not.exist()
             expect(entries.sort((a, b) => a.name.localeCompare(b.name))).to.eql([

--- a/src/files-mfs/ls-readable-stream.js
+++ b/src/files-mfs/ls-readable-stream.js
@@ -69,7 +69,7 @@ module.exports = (createCommon, options) => {
       })
     })
 
-    it('should ls -l directory', (done) => {
+    it('should ls directory with long option', (done) => {
       const testDir = `/test-${hat()}`
 
       series([
@@ -78,7 +78,7 @@ module.exports = (createCommon, options) => {
       ], (err) => {
         expect(err).to.not.exist()
 
-        const stream = ipfs.files.lsReadableStream(testDir, { l: true })
+        const stream = ipfs.files.lsReadableStream(testDir, { long: true })
 
         let entries = []
 

--- a/src/files-mfs/ls.js
+++ b/src/files-mfs/ls.js
@@ -62,7 +62,7 @@ module.exports = (createCommon, options) => {
       })
     })
 
-    it('should ls -l directory', (done) => {
+    it('should ls directory with long option', (done) => {
       const testDir = `/test-${hat()}`
 
       series([
@@ -71,7 +71,7 @@ module.exports = (createCommon, options) => {
       ], (err) => {
         expect(err).to.not.exist()
 
-        ipfs.files.ls(testDir, { l: true }, (err, info) => {
+        ipfs.files.ls(testDir, { long: true }, (err, info) => {
           expect(err).to.not.exist()
           expect(info.sort((a, b) => a.name.localeCompare(b.name))).to.eql([
             {


### PR DESCRIPTION
Will not pass in go-ipfs until `--long` is implemented.

https://github.com/ipfs/go-ipfs/pull/6528