### PR TITLE
chore: integrate libp2p new pubsub routing

### DIFF
--- a/SPEC/PUBSUB.md
+++ b/SPEC/PUBSUB.md
@@ -106,7 +106,7 @@ A great source of [examples][] can be found in the tests for this API.
 ##### `ipfs.pubsub.publish(topic, data, [callback])`
 
 - `topic: String`
-- `data: Buffer` - The message to send
+- `data: Buffer|String` - The message to send
 - `callback: (Error) => {}` - (Optional) Calls back with an error or nothing if the publish was successful.
 
 If no `callback` is passed, a promise is returned.

--- a/src/pubsub/publish.js
+++ b/src/pubsub/publish.js
@@ -32,15 +32,9 @@ module.exports = (createCommon, options) => {
 
     after((done) => common.teardown(done))
 
-    it('should error on string messags', async () => {
+    it('should publish message from string', () => {
       const topic = getTopic()
-      try {
-        await ipfs.pubsub.publish(topic, 'hello friend')
-      } catch (err) {
-        expect(err).to.exist()
-        return
-      }
-      throw new Error('did not error on string message')
+      return ipfs.pubsub.publish(topic, 'hello friend')
     })
 
     it('should publish message from buffer', () => {


### PR DESCRIPTION
On [libp2p/js-libp2p#365](https://github.com/libp2p/js-libp2p/pull/365), we decided to accept strings as the data being published. This usually was a barrier for entry users, so we just convert from string to buffer, if we receive a string.

Needs:

- [x] js-libp2p release with [libp2p/js-libp2p#365](https://github.com/libp2p/js-libp2p/pull/365)