### PR TITLE
Added in a test for the opts parameter.

### DIFF
--- a/SPEC/OBJECT.md
+++ b/SPEC/OBJECT.md
@@ -198,7 +198,8 @@ A great source of [examples][] can be found in the tests for this API.
 
 `options` is a optional argument of type object, that can contain the following properties:
 
-- `enc`, the encoding of multihash (base58, base64, etc), if any.
+- `enc`, The encoding type the output should beencoded with (json, xml, or text), if any.
+- `timeout`, A timeout to pass to the IPFS daemon so the request expires after a certain amount of time.
 
 `callback` must follow `function (err, stats) {}` signature, where `err` is an error if the operation was not successful and `stats` is an Object with following format:
 
@@ -220,7 +221,7 @@ If no `callback` is passed, a [promise][] is returned.
 ```JavaScript
 const multihash = 'QmPTkMuuL6PD8L2SwTwbcs1NPg14U8mRzerB1ZrrBrkSDD'
 
-ipfs.object.stat(multihash, (err, stats) => {
+ipfs.object.stat(multihash, {timeout: '10s'}, (err, stats) => {
   if (err) {
     throw err
   }

--- a/SPEC/OBJECT.md
+++ b/SPEC/OBJECT.md
@@ -198,7 +198,6 @@ A great source of [examples][] can be found in the tests for this API.
 
 `options` is a optional argument of type object, that can contain the following properties:
 
-- `enc`, The encoding type the output should beencoded with (json, xml, or text), if any.
 - `timeout`, A timeout to pass to the IPFS daemon so the request expires after a certain amount of time without any response. NOTE: not yet supported in JS IPFS.
 
 `callback` must follow `function (err, stats) {}` signature, where `err` is an error if the operation was not successful and `stats` is an Object with following format:

--- a/SPEC/OBJECT.md
+++ b/SPEC/OBJECT.md
@@ -199,7 +199,7 @@ A great source of [examples][] can be found in the tests for this API.
 `options` is a optional argument of type object, that can contain the following properties:
 
 - `enc`, The encoding type the output should beencoded with (json, xml, or text), if any.
-- `timeout`, A timeout to pass to the IPFS daemon so the request expires after a certain amount of time.
+- `timeout`, A timeout to pass to the IPFS daemon so the request expires after a certain amount of time without any response. NOTE: not yet supported in JS IPFS.
 
 `callback` must follow `function (err, stats) {}` signature, where `err` is an error if the operation was not successful and `stats` is an Object with following format:
 

--- a/src/object/stat.js
+++ b/src/object/stat.js
@@ -67,7 +67,7 @@ module.exports = (createCommon, options) => {
       }
 
       await ipfs.object.put(testObj)
-      const stats = await ipfs.object.stat('QmNggDXca24S6cMPEYHZjeuc4QRmofkRrAEqVL3Ms2sdJZ', { enc: 'base58' })
+      const stats = await ipfs.object.stat('QmNggDXca24S6cMPEYHZjeuc4QRmofkRrAEqVL3Ms2sdJZ')
 
       const expected = {
         Hash: 'QmNggDXca24S6cMPEYHZjeuc4QRmofkRrAEqVL3Ms2sdJZ',
@@ -79,6 +79,30 @@ module.exports = (createCommon, options) => {
       }
 
       expect(expected).to.deep.equal(stats)
+    })
+    
+    it('should pass on the opts', (done) => {
+      const testObj = {
+        Data: Buffer.from('get test object'),
+        Links: []
+      }
+
+      ipfs.object.put(testObj, (err, cid) => {
+        expect(err).to.not.exist()
+        const timeout = 2;
+        const startTime = new Date();
+        const badCid = 'QmNggDXca24S6cMPEYHZjeuc4QRmofkRrAEqVL3MzzzzzZ';
+
+        //we can test that we are passing in opts by testing the timeout option for a CID that doesn't exist
+        ipfs.object.stat(badCid, {timeout: `${timeout}s`}, (err, stats) => {
+          let timeForRequest = (new Date () - startTime)/1000;
+          console.log(err);
+          expect(err.message).to.equal("failed to get block for QmNggDXca24S6cMPEYHZjeuc4QRmofkRrAEqVL3MzzzzzZ: context deadline exceeded");
+          expect(stats).to.not.exist()
+          expect(timeForRequest).to.not.lessThan(timeout);
+          done()
+        })
+      })
     })
 
     it('should get stats for object with links by multihash', (done) => {
@@ -151,7 +175,7 @@ module.exports = (createCommon, options) => {
       ipfs.object.put(testObj, (err, cid) => {
         expect(err).to.not.exist()
 
-        ipfs.object.stat(cid.buffer, { enc: 'base58' }, (err, stats) => {
+        ipfs.object.stat(cid.buffer, (err, stats) => {
           expect(err).to.not.exist()
           const expected = {
             Hash: 'QmNggDXca24S6cMPEYHZjeuc4QRmofkRrAEqVL3Ms2sdJZ',
@@ -176,7 +200,7 @@ module.exports = (createCommon, options) => {
       ipfs.object.put(testObj, (err, cid) => {
         expect(err).to.not.exist()
 
-        ipfs.object.stat(cid.toBaseEncodedString(), { enc: 'base58' }, (err, stats) => {
+        ipfs.object.stat(cid.toBaseEncodedString(), (err, stats) => {
           expect(err).to.not.exist()
           const expected = {
             Hash: 'QmNggDXca24S6cMPEYHZjeuc4QRmofkRrAEqVL3Ms2sdJZ',

--- a/src/object/stat.js
+++ b/src/object/stat.js
@@ -80,26 +80,26 @@ module.exports = (createCommon, options) => {
 
       expect(expected).to.deep.equal(stats)
     })
-    
+
     it('should pass on the opts', (done) => {
       const testObj = {
         Data: Buffer.from('get test object'),
         Links: []
       }
 
-      ipfs.object.put(testObj, (err, cid) => {
+      ipfs.object.put(testObj, (err) => {
         expect(err).to.not.exist()
-        const timeout = 2;
-        const startTime = new Date();
-        const badCid = 'QmNggDXca24S6cMPEYHZjeuc4QRmofkRrAEqVL3MzzzzzZ';
+        const timeout = 2
+        const startTime = new Date()
+        const badCid = 'QmNggDXca24S6cMPEYHZjeuc4QRmofkRrAEqVL3MzzzzzZ'
 
-        //we can test that we are passing in opts by testing the timeout option for a CID that doesn't exist
-        ipfs.object.stat(badCid, {timeout: `${timeout}s`}, (err, stats) => {
-          let timeForRequest = (new Date () - startTime)/1000;
-          console.log(err);
-          expect(err.message).to.equal("failed to get block for QmNggDXca24S6cMPEYHZjeuc4QRmofkRrAEqVL3MzzzzzZ: context deadline exceeded");
+        // we can test that we are passing in opts by testing the timeout option for a CID that doesn't exist
+        ipfs.object.stat(badCid, { timeout: `${timeout}s` }, (err, stats) => {
+          const timeForRequest = (new Date() - startTime) / 1000
+          expect(err).to.exist()
+          expect(err.message).to.equal('failed to get block for QmNggDXca24S6cMPEYHZjeuc4QRmofkRrAEqVL3MzzzzzZ: context deadline exceeded')
           expect(stats).to.not.exist()
-          expect(timeForRequest).to.not.lessThan(timeout);
+          expect(timeForRequest).to.not.lessThan(timeout)
           done()
         })
       })

--- a/src/object/stat.js
+++ b/src/object/stat.js
@@ -100,6 +100,7 @@ module.exports = (createCommon, options) => {
           expect(err.message).to.equal('failed to get block for QmNggDXca24S6cMPEYHZjeuc4QRmofkRrAEqVL3MzzzzzZ: context deadline exceeded')
           expect(stats).to.not.exist()
           expect(timeForRequest).to.not.lessThan(timeout)
+          expect(timeForRequest).to.not.greaterThan(timeout + 1)
           done()
         })
       })

--- a/src/object/stat.js
+++ b/src/object/stat.js
@@ -81,7 +81,7 @@ module.exports = (createCommon, options) => {
       expect(expected).to.deep.equal(stats)
     })
 
-    it('should pass on the opts', (done) => {
+    it('should respect timeout option', (done) => {
       const testObj = {
         Data: Buffer.from('get test object'),
         Links: []


### PR DESCRIPTION
The opts parameter wasn't correctly passed in when calling ipfs.object.stat. This is the test that makes sure opts is being correctly passed to through the send function to the IPFS daemon. 

I've also removed the "base58" encoding that was being passed in for some tests as base58 isn't a valid option for encoding and would provide this error: 

Uncaught AssertionError: expected [Error: invalid encoding: base58] to not exist