### PR TITLE
test: add test for add files to dir non sequentially

### DIFF
--- a/src/files-regular/add.js
+++ b/src/files-regular/add.js
@@ -325,6 +325,33 @@ module.exports = (createCommon, options) => {
       })
     })
 
+    it('should add files to a directory non sequentially', function (done) {
+      const content = path => ({
+        path: `test-dir/${path}`,
+        content: fixtures.directory.files[path.split('/').pop()]
+      })
+
+      const input = [
+        content('a/pp.txt'),
+        content('a/holmes.txt'),
+        content('b/jungle.txt'),
+        content('a/alice.txt')
+      ]
+
+      ipfs.add(input, (err, filesAdded) => {
+        expect(err).to.not.exist()
+
+        const toPath = ({ path }) => path
+        const nonSeqDirFilePaths = input.map(toPath).filter(p => p.includes('/a/'))
+        const filesAddedPaths = filesAdded.map(toPath)
+
+        expect(nonSeqDirFilePaths.every(p => filesAddedPaths.includes(p)))
+          .to.be.true()
+
+        done()
+      })
+    })
+
     it('should fail when passed invalid input', (done) => {
       const nonValid = 'sfdasfasfs'
 


### PR DESCRIPTION
Output is:

```js
[
  {
    path: 'test-dir/b/jungle.txt',
    hash: 'QmT6orWioMiSqXXPGsUi71CKRRUmJ8YkuueV2DPV34E9y9',
    size: 2305
  },
  {
    path: 'test-dir/b',
    hash: 'QmfQm3xnDNKHRxPxb3z1UA81Cst8wWdA93dZC6oPRbTWHm',
    size: 2362
  },
  {
    path: 'test-dir/a/pp.txt',
    hash: 'QmVwdDCY4SPGVFnNCiZnX5CtzwWDn6kAM98JXzKxE3kCmn',
    size: 4551
  },
  {
    path: 'test-dir/a/holmes.txt',
    hash: 'QmR4nFjTu18TyANgC65ArNWp5Yaab1gPzQ4D8zp7Kx3vhr',
    size: 582072
  },
  {
    path: 'test-dir/a/alice.txt',
    hash: 'QmZyUEQVuRK3XV7L9Dk26pg6RVSgaYkiSTEdnT2kZZdwoi',
    size: 11696
  },
  {
    path: 'test-dir/a',
    hash: 'QmXh4P8PwnYDrN62u1GRunyhoEnW68vTR7TXkBxodkxsmw',
    size: 598478
  },
  {
    path: 'test-dir',
    hash: 'QmVBueuZRsuNgvExGFyTUGcLs2pdUMaKWrXu5fY37BaT2T',
    size: 600933
  }
]
```