### PR TITLE
fix(ci): avoid fs clash during ipfs.add* on Windows

### DIFF
--- a/src/files-regular/add-from-url.js
+++ b/src/files-regular/add-from-url.js
@@ -2,7 +2,7 @@
 'use strict'
 
 const { getDescribe, getIt, expect } = require('../utils/mocha')
-const parallel = require('async/parallel')
+const series = require('async/series')
 const { echoUrl, redirectUrl } = require('../utils/echo-http-server')
 
 module.exports = (createCommon, options) => {
@@ -34,7 +34,7 @@ module.exports = (createCommon, options) => {
     it('should add from a HTTP URL', (done) => {
       const text = `TEST${Date.now()}`
       const url = echoUrl(text)
-      parallel({
+      series({
         result: (cb) => ipfs.addFromURL(url, cb),
         expectedResult: (cb) => ipfs.add(Buffer.from(text), cb)
       }, (err, { result, expectedResult }) => {
@@ -52,7 +52,7 @@ module.exports = (createCommon, options) => {
       const text = `TEST${Date.now()}`
       const url = echoUrl(text) + '?foo=bar#buzz'
 
-      parallel({
+      series({
         result: (cb) => ipfs.addFromURL(redirectUrl(url), cb),
         expectedResult: (cb) => ipfs.add(Buffer.from(text), cb)
       }, (err, { result, expectedResult }) => {
@@ -91,7 +91,7 @@ module.exports = (createCommon, options) => {
       const filename = `TEST${Date.now()}.txt` // also acts as data
       const url = echoUrl(filename) + '?foo=bar#buzz'
       const addOpts = { wrapWithDirectory: true }
-      parallel({
+      series({
         result: (cb) => ipfs.addFromURL(url, addOpts, cb),
         expectedResult: (cb) => ipfs.add([{ path: filename, content: Buffer.from(filename) }], addOpts, cb)
       }, (err, { result, expectedResult }) => {
@@ -107,7 +107,7 @@ module.exports = (createCommon, options) => {
       const filename = `320px-Domažlice,_Jiráskova_43_(${Date.now()}).jpg` // also acts as data
       const url = echoUrl(filename) + '?foo=bar#buzz'
       const addOpts = { wrapWithDirectory: true }
-      parallel({
+      series({
         result: (cb) => ipfs.addFromURL(url, addOpts, cb),
         expectedResult: (cb) => ipfs.add([{ path: filename, content: Buffer.from(filename) }], addOpts, cb)
       }, (err, { result, expectedResult }) => {


### PR DESCRIPTION
This PR fixes random TravisCI failures on Windows and unblocks https://github.com/ipfs/js-ipfs/pull/2304

### Root cause


Windows issue was triggered by parallel `ipfs.add*` of the same data:

```js
      parallel({
        result: (cb) => ipfs.addFromURL(url, cb),
        expectedResult: (cb) => ipfs.add(Buffer.from(text), cb)
      }, (err, { result, expectedResult }) => {
        expect(err).to.not.exist()
```

Both `addFromURL` and `add` added the same data, touched same files on filesystem, triggering a known problem with Node on Windows and Travis:

- https://travis-ci.community/t/eperm-operation-not-permitted-nodejs-electron/2571

### Fix 

One way to fix this type of error is to run as Windows Administrator. It does not seem to be feasible for TravisCI.

Instead, switching to sequential mode of operation removes `addFromURL` tests as a surface for file system race conditions on Windows.
