### PR TITLE
feat: add support for async/await setup in the swarm tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "chai": "^4.2.0",
     "cids": "~0.7.1",
     "concat-stream": "^2.0.0",
+    "delay": "^4.3.0",
     "dirty-chai": "^2.0.1",
     "es6-promisify": "^6.0.1",
     "hat": "0.0.3",

--- a/src/miscellaneous/id.js
+++ b/src/miscellaneous/id.js
@@ -8,13 +8,13 @@ module.exports = (createCommon, options) => {
   const it = getIt(options)
   const common = createCommon()
 
-  describe('.id', () => {
+  describe('.id', function () {
+    this.timeout(60 * 1000)
     let ipfs
 
     before(function (done) {
       // CI takes longer to instantiate the daemon, so we need to increase the
       // timeout for the before step
-      this.timeout(60 * 1000)
 
       common.setup((err, factory) => {
         expect(err).to.not.exist()

--- a/src/miscellaneous/id.js
+++ b/src/miscellaneous/id.js
@@ -13,9 +13,6 @@ module.exports = (createCommon, options) => {
     let ipfs
 
     before(function (done) {
-      // CI takes longer to instantiate the daemon, so we need to increase the
-      // timeout for the before step
-
       common.setup((err, factory) => {
         expect(err).to.not.exist()
         factory.spawnNode((err, node) => {

--- a/src/miscellaneous/resolve.js
+++ b/src/miscellaneous/resolve.js
@@ -15,7 +15,8 @@ module.exports = (createCommon, options) => {
   const it = getIt(options)
   const common = createCommon()
 
-  describe('.resolve', () => {
+  describe('.resolve', function () {
+    this.timeout(60 * 1000)
     let ipfs
     let nodeId
 

--- a/src/swarm/addrs.js
+++ b/src/swarm/addrs.js
@@ -3,7 +3,6 @@
 
 const PeerInfo = require('peer-info')
 const { getDescribe, getIt, expect } = require('../utils/mocha')
-const { spawnNodesWithId } = require('../utils/spawn')
 
 module.exports = (createCommon, options) => {
   const describe = getDescribe(options)
@@ -11,28 +10,18 @@ module.exports = (createCommon, options) => {
   const common = createCommon()
 
   describe('.swarm.addrs', function () {
-    this.timeout(80 * 1000)
+    this.timeout(60 * 1000)
 
-    let ipfsA, ipfsB
+    let ipfsA
+    let ipfsB
 
-    before(function (done) {
-      // CI takes longer to instantiate the daemon, so we need to increase the
-      // timeout for the before step
-      this.timeout(100 * 1000)
-
-      common.setup((err, factory) => {
-        expect(err).to.not.exist()
-
-        spawnNodesWithId(2, factory, (err, nodes) => {
-          expect(err).to.not.exist()
-          ipfsA = nodes[0]
-          ipfsB = nodes[1]
-          ipfsA.swarm.connect(ipfsB.peerId.addresses[0], done)
-        })
-      })
+    before(async () => {
+      ipfsA = await common.setup()
+      ipfsB = await common.setup()
+      await ipfsA.swarm.connect(ipfsB.peerId.addresses[0])
     })
 
-    after((done) => common.teardown(done))
+    after(() => common.teardown())
 
     it('should get a list of node addresses', (done) => {
       ipfsA.swarm.addrs((err, peerInfos) => {

--- a/src/swarm/addrs.js
+++ b/src/swarm/addrs.js
@@ -10,7 +10,7 @@ module.exports = (createCommon, options) => {
   const common = createCommon()
 
   describe('.swarm.addrs', function () {
-    this.timeout(60 * 1000)
+    this.timeout(80 * 1000)
 
     let ipfsA
     let ipfsB

--- a/src/swarm/connect.js
+++ b/src/swarm/connect.js
@@ -9,7 +9,7 @@ module.exports = (createCommon, options) => {
   const common = createCommon()
 
   describe('.swarm.connect', function () {
-    this.timeout(10000)
+    this.timeout(60000)
     let ipfsA
     let ipfsB
 

--- a/src/swarm/connect.js
+++ b/src/swarm/connect.js
@@ -9,7 +9,7 @@ module.exports = (createCommon, options) => {
   const common = createCommon()
 
   describe('.swarm.connect', function () {
-    this.timeout(60 * 1000)
+    this.timeout(80 * 1000)
     let ipfsA
     let ipfsB
 

--- a/src/swarm/connect.js
+++ b/src/swarm/connect.js
@@ -9,7 +9,7 @@ module.exports = (createCommon, options) => {
   const common = createCommon()
 
   describe('.swarm.connect', function () {
-    this.timeout(60000)
+    this.timeout(60 * 1000)
     let ipfsA
     let ipfsB
 

--- a/src/swarm/connect.js
+++ b/src/swarm/connect.js
@@ -1,8 +1,7 @@
 /* eslint-env mocha */
 'use strict'
 
-const { spawnNodesWithId } = require('../utils/spawn')
-const { getDescribe, getIt, expect } = require('../utils/mocha')
+const { getDescribe, getIt } = require('../utils/mocha')
 
 module.exports = (createCommon, options) => {
   const describe = getDescribe(options)
@@ -10,29 +9,16 @@ module.exports = (createCommon, options) => {
   const common = createCommon()
 
   describe('.swarm.connect', function () {
-    this.timeout(80 * 1000)
-
+    this.timeout(10000)
     let ipfsA
     let ipfsB
 
-    before(function (done) {
-      // CI takes longer to instantiate the daemon, so we need to increase the
-      // timeout for the before step
-      this.timeout(100 * 1000)
-
-      common.setup((err, factory) => {
-        expect(err).to.not.exist()
-
-        spawnNodesWithId(2, factory, (err, nodes) => {
-          expect(err).to.not.exist()
-          ipfsA = nodes[0]
-          ipfsB = nodes[1]
-          done()
-        })
-      })
+    before(async () => {
+      ipfsA = await common.setup()
+      ipfsB = await common.setup()
     })
 
-    after((done) => common.teardown(done))
+    after(() => common.teardown())
 
     it('should connect to a peer', (done) => {
       ipfsA.swarm.connect(ipfsB.peerId.addresses[0], done)

--- a/src/swarm/disconnect.js
+++ b/src/swarm/disconnect.js
@@ -9,7 +9,7 @@ module.exports = (createCommon, options) => {
   const common = createCommon()
 
   describe('.swarm.disconnect', function () {
-    this.timeout(60 * 1000)
+    this.timeout(80 * 1000)
 
     let ipfsA
     let ipfsB

--- a/src/swarm/disconnect.js
+++ b/src/swarm/disconnect.js
@@ -1,8 +1,7 @@
 /* eslint-env mocha */
 'use strict'
 
-const { spawnNodesWithId } = require('../utils/spawn')
-const { getDescribe, getIt, expect } = require('../utils/mocha')
+const { getDescribe, getIt } = require('../utils/mocha')
 
 module.exports = (createCommon, options) => {
   const describe = getDescribe(options)
@@ -10,29 +9,18 @@ module.exports = (createCommon, options) => {
   const common = createCommon()
 
   describe('.swarm.disconnect', function () {
-    this.timeout(80 * 1000)
+    this.timeout(60 * 1000)
 
     let ipfsA
     let ipfsB
 
-    before(function (done) {
-      // CI takes longer to instantiate the daemon, so we need to increase the
-      // timeout for the before step
-      this.timeout(100 * 1000)
-
-      common.setup((err, factory) => {
-        expect(err).to.not.exist()
-
-        spawnNodesWithId(2, factory, (err, nodes) => {
-          expect(err).to.not.exist()
-          ipfsA = nodes[0]
-          ipfsB = nodes[1]
-          ipfsA.swarm.connect(ipfsB.peerId.addresses[0], done)
-        })
-      })
+    before(async () => {
+      ipfsA = await common.setup()
+      ipfsB = await common.setup()
+      await ipfsA.swarm.connect(ipfsB.peerId.addresses[0])
     })
 
-    after((done) => common.teardown(done))
+    after(() => common.teardown())
 
     it('should disconnect from a peer', (done) => {
       ipfsA.swarm.disconnect(ipfsB.peerId.addresses[0], done)

--- a/src/swarm/local-addrs.js
+++ b/src/swarm/local-addrs.js
@@ -9,7 +9,7 @@ module.exports = (createCommon, options) => {
   const common = createCommon()
 
   describe('.swarm.localAddrs', function () {
-    this.timeout(60 * 1000)
+    this.timeout(80 * 1000)
 
     let ipfs
 

--- a/src/swarm/local-addrs.js
+++ b/src/swarm/local-addrs.js
@@ -9,26 +9,15 @@ module.exports = (createCommon, options) => {
   const common = createCommon()
 
   describe('.swarm.localAddrs', function () {
-    this.timeout(80 * 1000)
+    this.timeout(60 * 1000)
 
     let ipfs
 
-    before(function (done) {
-      // CI takes longer to instantiate the daemon, so we need to increase the
-      // timeout for the before step
-      this.timeout(100 * 1000)
-
-      common.setup((err, factory) => {
-        expect(err).to.not.exist()
-        factory.spawnNode((err, node) => {
-          expect(err).to.not.exist()
-          ipfs = node
-          done()
-        })
-      })
+    before(async () => {
+      ipfs = await common.setup()
     })
 
-    after((done) => common.teardown(done))
+    after(() => common.teardown())
 
     it('should list local addresses the node is listening on', (done) => {
       ipfs.swarm.localAddrs((err, multiaddrs) => {

--- a/src/swarm/peers.js
+++ b/src/swarm/peers.js
@@ -1,13 +1,9 @@
 /* eslint-env mocha */
 'use strict'
 
-const auto = require('async/auto')
 const multiaddr = require('multiaddr')
 const PeerId = require('peer-id')
-const os = require('os')
-const path = require('path')
-const hat = require('hat')
-const { spawnNodesWithId } = require('../utils/spawn')
+const delay = require('delay')
 const { getDescribe, getIt, expect } = require('../utils/mocha')
 
 module.exports = (createCommon, options) => {
@@ -16,31 +12,18 @@ module.exports = (createCommon, options) => {
   const common = createCommon()
 
   describe('.swarm.peers', function () {
-    this.timeout(80 * 1000)
+    this.timeout(60 * 1000)
 
     let ipfsA
     let ipfsB
-    let ipfsFactory
 
-    before(function (done) {
-      // CI takes longer to instantiate the daemon, so we need to increase the
-      // timeout for the before step
-      this.timeout(100 * 1000)
-
-      common.setup((err, factory) => {
-        expect(err).to.not.exist()
-        ipfsFactory = factory
-
-        spawnNodesWithId(2, factory, (err, nodes) => {
-          expect(err).to.not.exist()
-          ipfsA = nodes[0]
-          ipfsB = nodes[1]
-          ipfsA.swarm.connect(ipfsB.peerId.addresses[0], done)
-        })
-      })
+    before(async () => {
+      ipfsA = await common.setup()
+      ipfsB = await common.setup()
+      await ipfsA.swarm.connect(ipfsB.peerId.addresses[0])
     })
 
-    after((done) => common.teardown(done))
+    after(() => common.teardown())
 
     it('should list peers this node is connected to', (done) => {
       ipfsA.swarm.peers((err, peers) => {
@@ -119,44 +102,20 @@ module.exports = (createCommon, options) => {
       }
     }
 
-    function getRepoPath () {
-      return path.join(os.tmpdir(), '.ipfs-' + hat())
-    }
-
-    it('should list peers only once', (done) => {
+    it('should list peers only once', async () => {
       const config = getConfig(['/ip4/127.0.0.1/tcp/0'])
 
-      auto({
-        nodeA: (cb) => ipfsFactory.spawnNode(getRepoPath(), config, cb),
-        nodeB: ['nodeA', (_, cb) => {
-          ipfsFactory.spawnNode(getRepoPath(), config, cb)
-        }],
-        nodeBAddress: ['nodeB', (res, cb) => {
-          res.nodeB.id((err, info) => {
-            if (err) return cb(err)
-            cb(null, info.addresses[0])
-          })
-        }],
-        connectA2B: ['nodeA', 'nodeBAddress', (res, cb) => {
-          res.nodeA.swarm.connect(res.nodeBAddress, cb)
-        }],
-        // time for identify
-        wait: ['connectA2B', (_, cb) => setTimeout(cb, 1000)],
-        nodeAPeers: ['nodeA', 'wait', (res, cb) => {
-          res.nodeA.swarm.peers(cb)
-        }],
-        nodeBPeers: ['nodeB', 'wait', (res, cb) => {
-          res.nodeB.swarm.peers(cb)
-        }]
-      }, (err, res) => {
-        expect(err).to.not.exist()
-        expect(res.nodeAPeers).to.have.length(1)
-        expect(res.nodeBPeers).to.have.length(1)
-        done()
-      })
+      const nodeA = await common.setup({}, { config })
+      const nodeB = await common.setup({}, { config })
+      await nodeA.swarm.connect(nodeB.peerId.addresses[0])
+      await delay(1000)
+      const peersA = await nodeA.swarm.peers()
+      const peersB = await nodeB.swarm.peers()
+      expect(peersA).to.have.length(1)
+      expect(peersB).to.have.length(1)
     })
 
-    it('should list peers only once even if they have multiple addresses', (done) => {
+    it('should list peers only once even if they have multiple addresses', async () => {
       // TODO: Change to port 0, needs: https://github.com/ipfs/interface-ipfs-core/issues/152
       const configA = getConfig([
         '/ip4/127.0.0.1/tcp/16543',
@@ -166,35 +125,14 @@ module.exports = (createCommon, options) => {
         '/ip4/127.0.0.1/tcp/26545',
         '/ip4/127.0.0.1/tcp/26546'
       ])
-
-      auto({
-        nodeA: (cb) => ipfsFactory.spawnNode(getRepoPath(), configA, cb),
-        nodeB: ['nodeA', (_, cb) => {
-          ipfsFactory.spawnNode(getRepoPath(), configB, cb)
-        }],
-        nodeBAddress: ['nodeB', (res, cb) => {
-          res.nodeB.id((err, info) => {
-            if (err) return cb(err)
-            cb(null, info.addresses[0])
-          })
-        }],
-        connectA2B: ['nodeA', 'nodeBAddress', (res, cb) => {
-          res.nodeA.swarm.connect(res.nodeBAddress, cb)
-        }],
-        // time for identify
-        wait: ['connectA2B', (_, cb) => setTimeout(cb, 1000)],
-        nodeAPeers: ['nodeA', 'wait', (res, cb) => {
-          res.nodeA.swarm.peers(cb)
-        }],
-        nodeBPeers: ['nodeB', 'wait', (res, cb) => {
-          res.nodeB.swarm.peers(cb)
-        }]
-      }, (err, res) => {
-        expect(err).to.not.exist()
-        expect(res.nodeAPeers).to.have.length(1)
-        expect(res.nodeBPeers).to.have.length(1)
-        done()
-      })
+      const nodeA = await common.setup({}, { configA })
+      const nodeB = await common.setup({}, { configB })
+      await nodeA.swarm.connect(nodeB.peerId.addresses[0])
+      await delay(1000)
+      const peersA = await nodeA.swarm.peers()
+      const peersB = await nodeB.swarm.peers()
+      expect(peersA).to.have.length(1)
+      expect(peersB).to.have.length(1)
     })
   })
 }

--- a/src/swarm/peers.js
+++ b/src/swarm/peers.js
@@ -12,7 +12,7 @@ module.exports = (createCommon, options) => {
   const common = createCommon()
 
   describe('.swarm.peers', function () {
-    this.timeout(60 * 1000)
+    this.timeout(80 * 1000)
 
     let ipfsA
     let ipfsB


### PR DESCRIPTION
This PR increases a couples of timeout and adds support for async/await setup in the swarm tests

More PRs will follow to move everything to async/await setup

the following PRs add support async setup:
https://github.com/ipfs/js-ipfs-http-client/pull/1105
https://github.com/ipfs/js-ipfs/pull/2428