### PR TITLE
test: add missing tests

### DIFF
--- a/src/block/get.js
+++ b/src/block/get.js
@@ -107,5 +107,13 @@ module.exports = (createCommon, options) => {
         })
       })
     })
+
+    it('should return an error for an invalid CID', () => {
+      return ipfs.block.get('invalid')
+        .then(
+          () => expect.fail('should have returned an error for invalid argument'),
+          (err) => expect(err).to.be.an.instanceof(Error)
+        )
+    })
   })
 }

--- a/src/block/stat.js
+++ b/src/block/stat.js
@@ -43,5 +43,21 @@ module.exports = (createCommon, options) => {
         done()
       })
     })
+
+    it('should return error for missing argument', () => {
+      return ipfs.block.stat(null)
+        .then(
+          () => expect.fail('should have thrown for missing parameter'),
+          (err) => expect(err).to.be.an.instanceof(Error)
+        )
+    })
+
+    it('should return error for invalid argument', () => {
+      return ipfs.block.stat('invalid')
+        .then(
+          () => expect.fail('should have thrown for invalid parameter'),
+          (err) => expect(err).to.be.an.instanceof(Error)
+        )
+    })
   })
 }

--- a/src/bootstrap/add.js
+++ b/src/bootstrap/add.js
@@ -60,5 +60,20 @@ module.exports = (createCommon, options) => {
         done()
       })
     })
+
+    it('should prevent duplicate inserts of bootstrap peers', async () => {
+      const removed = await ipfs.bootstrap.rm(null, { all: true })
+      expect(removed).to.have.property('Peers').that.is.an('array')
+      expect(removed.Peers).to.have.lengthOf(0)
+
+      const added = await ipfs.bootstrap.add(validIp4)
+      expect(added).to.have.property('Peers').that.deep.equals([validIp4])
+
+      const addedAgain = await ipfs.bootstrap.add(validIp4)
+      expect(addedAgain).to.have.property('Peers').that.deep.equals([validIp4])
+
+      const list = await ipfs.bootstrap.list()
+      expect(list).to.have.property('Peers').that.deep.equals([validIp4])
+    })
   })
 }

--- a/src/config/set.js
+++ b/src/config/set.js
@@ -72,6 +72,22 @@ module.exports = (createCommon, options) => {
       })
     })
 
+    it('should set a boolean', async () => {
+      const value = true
+      const key = 'Datastore.Path'
+
+      await ipfs.config.set(key, value)
+      expect(await ipfs.config.get(key)).to.equal(value)
+    })
+
+    it('should set the other boolean', async () => {
+      const value = false
+      const key = 'Datastore.Path'
+
+      await ipfs.config.set(key, value)
+      expect(await ipfs.config.get(key)).to.equal(value)
+    })
+
     it('should set a JSON object', (done) => {
       const key = 'API.HTTPHeaders.Access-Control-Allow-Origin'
       const val = ['http://example.io']

--- a/src/files-mfs/ls.js
+++ b/src/files-mfs/ls.js
@@ -91,5 +91,29 @@ module.exports = (createCommon, options) => {
         })
       })
     })
+
+    it('should list an empty directory', async () => {
+      const testDir = `/test-${hat()}`
+      await ipfs.files.mkdir(testDir)
+      const contents = await ipfs.files.ls(testDir)
+
+      expect(contents).to.be.an('array').and.to.be.empty()
+    })
+
+    it('should list an file directly', async () => {
+      const fileName = `single-file-${hat()}.txt`
+      const filePath = `/${fileName}`
+      await ipfs.files.write(filePath, Buffer.from('Hello world'), {
+        create: true
+      })
+      const contents = await ipfs.files.ls(filePath)
+
+      expect(contents).to.be.an('array').and.have.lengthOf(1).and.to.deep.equal([{
+        hash: '',
+        name: fileName,
+        size: 0,
+        type: 0
+      }])
+    })
   })
 }

--- a/src/object/data.js
+++ b/src/object/data.js
@@ -118,5 +118,21 @@ module.exports = (createCommon, options) => {
         })
       })
     })
+
+    it('returns error for request without argument', () => {
+      return ipfs.object.data(null)
+        .then(
+          () => expect.fail('should have returned an error for invalid argument'),
+          (err) => expect(err).to.be.an.instanceof(Error)
+        )
+    })
+
+    it('returns error for request with invalid argument', () => {
+      ipfs.object.data('invalid', { enc: 'base58' })
+        .then(
+          () => expect.fail('should have returned an error for invalid argument'),
+          (err) => expect(err).to.be.an.instanceof(Error)
+        )
+    })
   })
 }

--- a/src/object/get.js
+++ b/src/object/get.js
@@ -336,5 +336,21 @@ module.exports = (createCommon, options) => {
           expect(meta.fileSize()).to.equal(data.length)
         })
     })
+
+    it('should error for request without argument', () => {
+      return ipfs.object.get(null)
+        .then(
+          () => expect.fail('should have returned an error for invalid argument'),
+          (err) => expect(err).to.be.an.instanceof(Error)
+        )
+    })
+
+    it('returns error for request with invalid argument', () => {
+      return ipfs.object.get('invalid', { enc: 'base58' })
+        .then(
+          () => expect.fail('should have returned an error for invalid argument'),
+          (err) => expect(err).to.be.an.instanceof(Error)
+        )
+    })
   })
 }

--- a/src/object/links.js
+++ b/src/object/links.js
@@ -206,5 +206,21 @@ module.exports = (createCommon, options) => {
         })
       })
     })
+
+    it('returns error for request without argument', () => {
+      return ipfs.object.links(null)
+        .then(
+          () => expect.fail('should have returned an error for invalid argument'),
+          (err) => expect(err).to.be.an.instanceof(Error)
+        )
+    })
+
+    it('returns error for request with invalid argument', () => {
+      ipfs.object.links('invalid', { enc: 'base58' })
+        .then(
+          () => expect.fail('should have returned an error for invalid argument'),
+          (err) => expect(err).to.be.an.instanceof(Error)
+        )
+    })
   })
 }

--- a/src/object/patch/add-link.js
+++ b/src/object/patch/add-link.js
@@ -163,5 +163,21 @@ module.exports = (createCommon, options) => {
 
       expect(newParentCid).to.eql(nodeFromObjectPatchCid)
     })
+
+    it('returns error for request without arguments', () => {
+      return ipfs.object.patch.addLink(null, null, null)
+        .then(
+          () => expect.fail('should have returned an error for invalid argument'),
+          (err) => expect(err).to.be.an.instanceof(Error)
+        )
+    })
+
+    it('returns error for request with only one invalid argument', () => {
+      return ipfs.object.patch.addLink('invalid', null, null)
+        .then(
+          () => expect.fail('should have returned an error for invalid argument'),
+          (err) => expect(err).to.be.an.instanceof(Error)
+        )
+    })
   })
 }

--- a/src/object/patch/append-data.js
+++ b/src/object/patch/append-data.js
@@ -59,5 +59,23 @@ module.exports = (createCommon, options) => {
 
       expect(nodeCid).to.not.deep.equal(patchedNodeCid)
     })
+
+    it('returns error for request without key & data', () => {
+      return ipfs.object.patch.appendData(null, null)
+        .then(
+          () => expect.fail('should have returned an error for invalid argument'),
+          (err) => expect(err).to.be.an.instanceof(Error)
+        )
+    })
+
+    it('returns error for request without data', () => {
+      const filePath = 'test/fixtures/test-data/badnode.json'
+
+      return ipfs.object.patch.appendData(null, filePath)
+        .then(
+          () => expect.fail('should have returned an error for invalid argument'),
+          (err) => expect(err).to.be.an.instanceof(Error)
+        )
+    })
   })
 }

--- a/src/object/patch/rm-link.js
+++ b/src/object/patch/rm-link.js
@@ -121,5 +121,32 @@ module.exports = (createCommon, options) => {
       expect(withoutChildCid).to.not.deep.equal(parentCid)
       expect(withoutChildCid).to.deep.equal(nodeCid)
     })
+
+    it('returns error for request without arguments', () => {
+      return ipfs.object.patch.rmLink(null, null)
+        .then(
+          () => expect.fail('should have returned an error for invalid argument'),
+          (err) => expect(err).to.be.an.instanceof(Error)
+        )
+    })
+
+    it('returns error for request only one invalid argument', () => {
+      return ipfs.object.patch.rmLink('invalid', null)
+        .then(
+          () => expect.fail('should have returned an error for invalid argument'),
+          (err) => expect(err).to.be.an.instanceof(Error)
+        )
+    })
+
+    it('returns error for request with invalid first argument', () => {
+      const root = ''
+      const link = 'foo'
+
+      return ipfs.object.patch.rmLink(root, link)
+        .then(
+          () => expect.fail('should have returned an error for invalid argument'),
+          (err) => expect(err).to.be.an.instanceof(Error)
+        )
+    })
   })
 }

--- a/src/object/patch/set-data.js
+++ b/src/object/patch/set-data.js
@@ -68,5 +68,23 @@ module.exports = (createCommon, options) => {
       expect(nodeCid).to.not.deep.equal(patchedNodeCid)
       expect(patchedNode.Data).to.eql(patchData)
     })
+
+    it('returns error for request without key & data', () => {
+      return ipfs.object.patch.setData(null, null)
+        .then(
+          () => expect.fail('should have returned an error for invalid argument'),
+          (err) => expect(err).to.be.an.instanceof(Error)
+        )
+    })
+
+    it('returns error for request without data', () => {
+      const filePath = 'test/fixtures/test-data/badnode.json'
+
+      return ipfs.object.patch.setData(null, filePath)
+        .then(
+          () => expect.fail('should have returned an error for invalid argument'),
+          (err) => expect(err).to.be.an.instanceof(Error)
+        )
+    })
   })
 }

--- a/src/object/stat.js
+++ b/src/object/stat.js
@@ -214,5 +214,21 @@ module.exports = (createCommon, options) => {
         })
       })
     })
+
+    it('returns error for request without argument', () => {
+      return ipfs.object.stat(null)
+        .then(
+          () => expect.fail('should have returned an error for invalid argument'),
+          (err) => expect(err).to.be.an.instanceof(Error)
+        )
+    })
+
+    it('returns error for request with invalid argument', () => {
+      return ipfs.object.stat('invalid', { enc: 'base58' })
+        .then(
+          () => expect.fail('should have returned an error for invalid argument'),
+          (err) => expect(err).to.be.an.instanceof(Error)
+        )
+    })
   })
 }


### PR DESCRIPTION
Our http tests in `js-IPFS` duplicate a whole bunch of tests from this suite, but they also test some unhappy paths that this suite does not.

I've pulled them out of `js-IPFS` as part of ipfs/js-ipfs#2495 and am adding them to the interface tests here.