### PR TITLE
fix: make invalid url actually invalid

### DIFF
--- a/src/files-regular/add-from-url.js
+++ b/src/files-regular/add-from-url.js
@@ -120,7 +120,7 @@ module.exports = (createCommon, options) => {
     })
 
     it('should not add from an invalid url', (done) => {
-      ipfs.addFromURL('http://invalid', (err, result) => {
+      ipfs.addFromURL('123http://invalid', (err, result) => {
         expect(err).to.exist()
         expect(result).to.not.exist()
         done()


### PR DESCRIPTION
I'm using one of those ISPs that 'helpfully' directs you to a search page if the URL you are accessing does not have a DNS match.

The URL used in the test was well formed but not a real domain though can be resolved, so this PR changes it to be something even a web-breaking DNS server would refuse to resolve.

![I hate you](https://user-images.githubusercontent.com/665810/65985898-a95b8080-e47a-11e9-9801-25b9adb09780.png)

