### PR TITLE
fix: configure chai for use by other modules

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "bs58": "^4.0.1",
     "callbackify": "^1.1.0",
     "chai": "^4.2.0",
+    "chai-as-promised": "^7.1.1",
     "cids": "~0.7.1",
     "concat-stream": "^2.0.0",
     "delay": "^4.3.0",

--- a/src/key/rename.js
+++ b/src/key/rename.js
@@ -2,13 +2,8 @@
 /* eslint max-nested-callbacks: ["error", 6] */
 'use strict'
 
-const chai = require('chai')
-const dirtyChai = require('dirty-chai')
 const hat = require('hat')
-const { getDescribe, getIt } = require('../utils/mocha')
-
-const expect = chai.expect
-chai.use(dirtyChai)
+const { getDescribe, getIt, expect } = require('../utils/mocha')
 
 module.exports = (createCommon, options) => {
   const describe = getDescribe(options)

--- a/src/utils/mocha.js
+++ b/src/utils/mocha.js
@@ -2,9 +2,10 @@
 'use strict'
 
 const chai = require('chai')
-const dirtyChai = require('dirty-chai')
 
-chai.use(dirtyChai)
+// Do not reorder these statements - https://github.com/chaijs/chai/issues/1298
+chai.use(require('chai-as-promised'))
+chai.use(require('dirty-chai'))
 
 module.exports.expect = chai.expect
 


### PR DESCRIPTION
Workaround for https://github.com/chaijs/chai/issues/1298

The order in which plugins are applied to chai is important and can break tests in other modules that run the tests from this one.