### PR TITLE
chore: do not assert on removed bootstrap nodes

### DIFF
--- a/src/bootstrap/add.js
+++ b/src/bootstrap/add.js
@@ -62,9 +62,7 @@ module.exports = (createCommon, options) => {
     })
 
     it('should prevent duplicate inserts of bootstrap peers', async () => {
-      const removed = await ipfs.bootstrap.rm(null, { all: true })
-      expect(removed).to.have.property('Peers').that.is.an('array')
-      expect(removed.Peers).to.have.lengthOf(0)
+      await ipfs.bootstrap.rm(null, { all: true })
 
       const added = await ipfs.bootstrap.add(validIp4)
       expect(added).to.have.property('Peers').that.deep.equals([validIp4])


### PR DESCRIPTION
Since it's not what we are testing here.