### PR TITLE
docs: add dry-run config test and change new/old for original/updated

### DIFF
--- a/SPEC/CONFIG.md
+++ b/SPEC/CONFIG.md
@@ -101,7 +101,7 @@ If no callback is passed, a [promise][] is returned
 **Example:**
 
 ```JavaScript
-ipfs.config.profiles.list(newConfig, (err, profiles) => {
+ipfs.config.profiles.list((err, profiles) => {
   if (err) {
     throw err
   }
@@ -135,8 +135,8 @@ ipfs.config.profiles.apply('lowpower', (err, diff) => {
     throw err
   }
 
-  console.info(diff.old)
-  console.info(diff.new)
+  console.info(diff.original)
+  console.info(diff.updated)
 })
 ```
 

--- a/src/config/profiles/apply.js
+++ b/src/config/profiles/apply.js
@@ -36,11 +36,32 @@ module.exports = (createCommon, options) => {
         (cb) => ipfs.config.profiles.apply('lowpower', cb),
         (_diff, cb) => {
           diff = _diff
-          expect(diff.old.Swarm.ConnMgr.LowWater).to.not.equal(diff.new.Swarm.ConnMgr.LowWater)
+          expect(diff.original.Swarm.ConnMgr.LowWater).to.not.equal(diff.updated.Swarm.ConnMgr.LowWater)
           ipfs.config.get(cb)
         },
         (newConfig, cb) => {
-          expect(newConfig.Swarm.ConnMgr.LowWater).to.equal(diff.new.Swarm.ConnMgr.LowWater)
+          expect(newConfig.Swarm.ConnMgr.LowWater).to.equal(diff.updated.Swarm.ConnMgr.LowWater)
+          cb()
+        }
+      ], done)
+    })
+
+    it('should not apply a config profile in dry-run mode', (done) => {
+      let originalConfig
+      waterfall([
+        (cb) => ipfs.config.get(cb),
+        (config, cb) => {
+          originalConfig = config
+          cb()
+        },
+        (cb) => ipfs.config.profiles.apply('server', { dryRun: true }, cb),
+        (diff, cb) => {
+          expect(diff.original).to.deep.equal(originalConfig)
+          expect(diff.updated).to.not.deep.equal(originalConfig)
+          ipfs.config.get(cb)
+        },
+        (updatedConfig, cb) => {
+          expect(updatedConfig).to.deep.equal(originalConfig)
           cb()
         }
       ], done)


### PR DESCRIPTION
Also corrects `ipfs.config.profiles.list` example.

BREAKING CHANGE:

`ipfs.config.profiles.apply` now returns `original`/`updated` keys in the diff because using `new` stops us from destructuring in js.

Sort of breaking, no implementation for this has been published yet.