### PR TITLE
feat: add support new ctl

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
   },
   "devDependencies": {
     "aegir": "^20.3.2",
-    "ipfsd-ctl": "github:ipfs/js-ipfsd-ctl#feat/interface-tests"
+    "ipfsd-ctl": "^1.0.0"
   },
   "contributors": [
     "Alan Shaw <alan.shaw@protocol.ai>",

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "ipld-dag-pb": "^0.18.1",
     "is-ipfs": "~0.6.1",
     "is-plain-object": "^3.0.0",
-    "it-pushable": "^1.2.1",
+    "it-pushable": "^1.3.1",
     "libp2p-crypto": "~0.16.0",
     "multiaddr": "^6.0.0",
     "multibase": "~0.6.0",
@@ -75,7 +75,8 @@
     "through2": "^3.0.0"
   },
   "devDependencies": {
-    "aegir": "^20.0.0"
+    "aegir": "^20.3.2",
+    "ipfsd-ctl": "ipfs/js-ipfsd-ctl#feat/interface-tests"
   },
   "contributors": [
     "Alan Shaw <alan.shaw@protocol.ai>",

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
   },
   "devDependencies": {
     "aegir": "^20.3.2",
-    "ipfsd-ctl": "ipfs/js-ipfsd-ctl#feat/interface-tests"
+    "ipfsd-ctl": "github:ipfs/js-ipfsd-ctl#feat/interface-tests"
   },
   "contributors": [
     "Alan Shaw <alan.shaw@protocol.ai>",

--- a/src/bitswap/stat.js
+++ b/src/bitswap/stat.js
@@ -4,19 +4,20 @@
 const { getDescribe, getIt, expect } = require('../utils/mocha')
 const { expectIsBitswap } = require('../stats/utils')
 
-module.exports = (createCommon, options) => {
+/** @typedef { import("ipfsd-ctl").TestsInterface } TestsInterface */
+/**
+ * @param {TestsInterface} common
+ * @param {Object} options
+ */
+module.exports = (common, options) => {
   const describe = getDescribe(options)
   const it = getIt(options)
-  const common = createCommon()
 
   describe('.bitswap.stat', () => {
+    this.timeout(60 * 1000)
     let ipfs
 
-    before(async function () {
-      // CI takes longer to instantiate the daemon, so we need to increase the
-      // timeout for the before step
-      this.timeout(60 * 1000)
-
+    before(async () => {
       ipfs = await common.setup()
     })
 
@@ -28,9 +29,7 @@ module.exports = (createCommon, options) => {
     })
 
     it('should not get bitswap stats when offline', async function () {
-      this.timeout(60 * 1000)
-
-      const node = await createCommon().setup()
+      const node = await common.node()
       await node.stop()
 
       return expect(node.bitswap.stat()).to.eventually.be.rejected()

--- a/src/bitswap/stat.js
+++ b/src/bitswap/stat.js
@@ -4,9 +4,9 @@
 const { getDescribe, getIt, expect } = require('../utils/mocha')
 const { expectIsBitswap } = require('../stats/utils')
 
-/** @typedef { import("ipfsd-ctl").TestsInterface } TestsInterface */
+/** @typedef { import("ipfsd-ctl/src/factory") } Factory */
 /**
- * @param {TestsInterface} common
+ * @param {Factory} common
  * @param {Object} options
  */
 module.exports = (common, options) => {
@@ -18,18 +18,18 @@ module.exports = (common, options) => {
     let ipfs
 
     before(async () => {
-      ipfs = await common.setup()
+      ipfs = (await common.spawn()).api
     })
 
-    after(() => common.teardown())
+    after(() => common.clean())
 
     it('should get bitswap stats', async () => {
       const res = await ipfs.bitswap.stat()
       expectIsBitswap(null, res)
     })
 
-    it('should not get bitswap stats when offline', async function () {
-      const node = await common.node()
+    it('should not get bitswap stats when offline', async () => {
+      const node = await common.spawn()
       await node.stop()
 
       return expect(node.api.bitswap.stat()).to.eventually.be.rejected()

--- a/src/bitswap/stat.js
+++ b/src/bitswap/stat.js
@@ -13,7 +13,7 @@ module.exports = (common, options) => {
   const describe = getDescribe(options)
   const it = getIt(options)
 
-  describe('.bitswap.stat', () => {
+  describe('.bitswap.stat', function () {
     this.timeout(60 * 1000)
     let ipfs
 

--- a/src/bitswap/stat.js
+++ b/src/bitswap/stat.js
@@ -32,7 +32,7 @@ module.exports = (common, options) => {
       const node = await common.node()
       await node.stop()
 
-      return expect(node.bitswap.stat()).to.eventually.be.rejected()
+      return expect(node.api.bitswap.stat()).to.eventually.be.rejected()
     })
   })
 }

--- a/src/bitswap/wantlist.js
+++ b/src/bitswap/wantlist.js
@@ -26,7 +26,6 @@ module.exports = (common, options) => {
 
       ipfsA = await common.setup()
       ipfsB = await common.setup({ type: 'js' })
-      await ipfsA.swarm.connect(ipfsB.peerId.addresses[0])
       // Add key to the wantlist for ipfsB
       ipfsB.block.get(key).catch(() => {})
     })
@@ -52,7 +51,7 @@ module.exports = (common, options) => {
       const node = await common.node()
       await node.stop()
 
-      return expect(node.bitswap.wantlist()).to.eventually.be.rejected()
+      return expect(node.api.bitswap.stat()).to.eventually.be.rejected()
     })
   })
 }

--- a/src/bitswap/wantlist.js
+++ b/src/bitswap/wantlist.js
@@ -24,6 +24,7 @@ module.exports = (common, options) => {
       ipfsB = (await common.spawn({ type: 'go' })).api
       // Add key to the wantlist for ipfsB
       ipfsB.block.get(key).catch(() => {})
+      await ipfsA.swarm.connect(ipfsB.peerId.addresses[0])
     })
 
     after(() => common.clean())

--- a/src/bitswap/wantlist.js
+++ b/src/bitswap/wantlist.js
@@ -25,7 +25,7 @@ module.exports = (common, options) => {
       this.timeout(60 * 1000)
 
       ipfsA = await common.setup()
-      ipfsB = await common.setup({ type: 'js' })
+      ipfsB = await common.setup({ type: 'go' })
       // Add key to the wantlist for ipfsB
       ipfsB.block.get(key).catch(() => {})
     })

--- a/src/bitswap/wantlist.js
+++ b/src/bitswap/wantlist.js
@@ -25,7 +25,7 @@ module.exports = (common, options) => {
       this.timeout(60 * 1000)
 
       ipfsA = await common.setup()
-      ipfsB = await common.setup()
+      ipfsB = await common.setup({ type: 'js' })
       await ipfsA.swarm.connect(ipfsB.peerId.addresses[0])
       // Add key to the wantlist for ipfsB
       ipfsB.block.get(key).catch(() => {})

--- a/src/bitswap/wantlist.js
+++ b/src/bitswap/wantlist.js
@@ -4,12 +4,17 @@
 const { getDescribe, getIt, expect } = require('../utils/mocha')
 const { waitForWantlistKey } = require('./utils')
 
-module.exports = (createCommon, options) => {
+/** @typedef { import("ipfsd-ctl").TestsInterface } TestsInterface */
+/**
+ * @param {TestsInterface} common
+ * @param {Object} options
+ */
+module.exports = (common, options) => {
   const describe = getDescribe(options)
   const it = getIt(options)
-  const common = createCommon()
 
-  describe('.bitswap.wantlist', () => {
+  describe('.bitswap.wantlist', function () {
+    this.timeout(60 * 1000)
     let ipfsA
     let ipfsB
     const key = 'QmUBdnXXPyoDFXj3Hj39dNJ5VkN3QFRskXxcGaYFBB8CNR'
@@ -21,11 +26,9 @@ module.exports = (createCommon, options) => {
 
       ipfsA = await common.setup()
       ipfsB = await common.setup()
-
+      await ipfsA.swarm.connect(ipfsB.peerId.addresses[0])
       // Add key to the wantlist for ipfsB
       ipfsB.block.get(key).catch(() => {})
-
-      await ipfsA.swarm.connect(ipfsB.peerId.addresses[0])
     })
 
     after(function () {
@@ -35,22 +38,18 @@ module.exports = (createCommon, options) => {
     })
 
     it('should get the wantlist', function () {
-      this.timeout(60 * 1000)
       return waitForWantlistKey(ipfsB, key)
     })
 
     it('should get the wantlist by peer ID for a different node', function () {
-      this.timeout(60 * 1000)
       return waitForWantlistKey(ipfsA, key, {
         peerId: ipfsB.peerId.id,
         timeout: 60 * 1000
       })
     })
 
-    it('should not get the wantlist when offline', async function () {
-      this.timeout(60 * 1000)
-
-      const node = await createCommon().setup()
+    it('should not get the wantlist when offline', async () => {
+      const node = await common.node()
       await node.stop()
 
       return expect(node.bitswap.wantlist()).to.eventually.be.rejected()

--- a/src/block/get.js
+++ b/src/block/get.js
@@ -5,10 +5,14 @@ const multihash = require('multihashes')
 const CID = require('cids')
 const { getDescribe, getIt, expect } = require('../utils/mocha')
 
-module.exports = (createCommon, options) => {
+/** @typedef { import("ipfsd-ctl").TestsInterface } TestsInterface */
+/**
+ * @param {TestsInterface} common
+ * @param {Object} options
+ */
+module.exports = (common, options) => {
   const describe = getDescribe(options)
   const it = getIt(options)
-  const common = createCommon()
 
   describe('.block.get', () => {
     const data = Buffer.from('blorb')

--- a/src/block/get.js
+++ b/src/block/get.js
@@ -5,9 +5,9 @@ const multihash = require('multihashes')
 const CID = require('cids')
 const { getDescribe, getIt, expect } = require('../utils/mocha')
 
-/** @typedef { import("ipfsd-ctl").TestsInterface } TestsInterface */
+/** @typedef { import("ipfsd-ctl/src/factory") } Factory */
 /**
- * @param {TestsInterface} common
+ * @param {Factory} common
  * @param {Object} options
  */
 module.exports = (common, options) => {
@@ -18,17 +18,13 @@ module.exports = (common, options) => {
     const data = Buffer.from('blorb')
     let ipfs, hash
 
-    before(async function () {
-      // CI takes longer to instantiate the daemon, so we need to increase the
-      // timeout for the before step
-      this.timeout(60 * 1000)
-
-      ipfs = await common.setup()
+    before(async () => {
+      ipfs = (await common.spawn()).api
       const block = await ipfs.block.put(data)
       hash = block.cid.multihash
     })
 
-    after(() => common.teardown())
+    after(() => common.clean())
 
     it('should get by CID object', async () => {
       const cid = new CID(hash)

--- a/src/block/put.js
+++ b/src/block/put.js
@@ -6,10 +6,14 @@ const multihash = require('multihashes')
 const CID = require('cids')
 const { getDescribe, getIt, expect } = require('../utils/mocha')
 
-module.exports = (createCommon, options) => {
+/** @typedef { import("ipfsd-ctl").TestsInterface } TestsInterface */
+/**
+ * @param {TestsInterface} common
+ * @param {Object} options
+ */
+module.exports = (common, options) => {
   const describe = getDescribe(options)
   const it = getIt(options)
-  const common = createCommon()
 
   describe('.block.put', () => {
     let ipfs

--- a/src/block/put.js
+++ b/src/block/put.js
@@ -6,9 +6,9 @@ const multihash = require('multihashes')
 const CID = require('cids')
 const { getDescribe, getIt, expect } = require('../utils/mocha')
 
-/** @typedef { import("ipfsd-ctl").TestsInterface } TestsInterface */
+/** @typedef { import("ipfsd-ctl/src/factory") } Factory */
 /**
- * @param {TestsInterface} common
+ * @param {Factory} common
  * @param {Object} options
  */
 module.exports = (common, options) => {
@@ -18,15 +18,11 @@ module.exports = (common, options) => {
   describe('.block.put', () => {
     let ipfs
 
-    before(async function () {
-      // CI takes longer to instantiate the daemon, so we need to increase the
-      // timeout for the before step
-      this.timeout(60 * 1000)
-
-      ipfs = await common.setup()
+    before(async () => {
+      ipfs = (await common.spawn()).api
     })
 
-    after(() => common.teardown())
+    after(() => common.clean())
 
     it('should put a buffer, using defaults', async () => {
       const expectedHash = 'QmPv52ekjS75L4JmHpXVeuJ5uX2ecSfSZo88NSyxwA3rAQ'

--- a/src/block/rm.js
+++ b/src/block/rm.js
@@ -4,21 +4,19 @@
 const { getDescribe, getIt, expect } = require('../utils/mocha')
 const hat = require('hat')
 
-module.exports = (createCommon, options) => {
+/** @typedef { import("ipfsd-ctl").TestsInterface } TestsInterface */
+/**
+ * @param {TestsInterface} common
+ * @param {Object} options
+ */
+module.exports = (common, options) => {
   const describe = getDescribe(options)
   const it = getIt(options)
-  const common = createCommon()
 
   describe('.block.rm', () => {
     let ipfs
 
-    before(async function () {
-      // CI takes longer to instantiate the daemon, so we need to increase the
-      // timeout for the before step
-      this.timeout(60 * 1000)
-
-      ipfs = await common.setup()
-    })
+    before(async () => { ipfs = await common.setup() })
 
     after(() => common.teardown())
 

--- a/src/block/rm.js
+++ b/src/block/rm.js
@@ -4,9 +4,9 @@
 const { getDescribe, getIt, expect } = require('../utils/mocha')
 const hat = require('hat')
 
-/** @typedef { import("ipfsd-ctl").TestsInterface } TestsInterface */
+/** @typedef { import("ipfsd-ctl/src/factory") } Factory */
 /**
- * @param {TestsInterface} common
+ * @param {Factory} common
  * @param {Object} options
  */
 module.exports = (common, options) => {
@@ -16,9 +16,9 @@ module.exports = (common, options) => {
   describe('.block.rm', () => {
     let ipfs
 
-    before(async () => { ipfs = await common.setup() })
+    before(async () => { ipfs = (await common.spawn()).api })
 
-    after(() => common.teardown())
+    after(() => common.clean())
 
     it('should remove by CID object', async () => {
       const cid = await ipfs.dag.put(Buffer.from(hat()), {

--- a/src/block/stat.js
+++ b/src/block/stat.js
@@ -4,10 +4,14 @@
 const CID = require('cids')
 const { getDescribe, getIt, expect } = require('../utils/mocha')
 
-module.exports = (createCommon, options) => {
+/** @typedef { import("ipfsd-ctl").TestsInterface } TestsInterface */
+/**
+ * @param {TestsInterface} common
+ * @param {Object} options
+ */
+module.exports = (common, options) => {
   const describe = getDescribe(options)
   const it = getIt(options)
-  const common = createCommon()
 
   describe('.block.stat', () => {
     const data = Buffer.from('blorb')

--- a/src/block/stat.js
+++ b/src/block/stat.js
@@ -4,9 +4,9 @@
 const CID = require('cids')
 const { getDescribe, getIt, expect } = require('../utils/mocha')
 
-/** @typedef { import("ipfsd-ctl").TestsInterface } TestsInterface */
+/** @typedef { import("ipfsd-ctl/src/factory") } Factory */
 /**
- * @param {TestsInterface} common
+ * @param {Factory} common
  * @param {Object} options
  */
 module.exports = (common, options) => {
@@ -17,17 +17,13 @@ module.exports = (common, options) => {
     const data = Buffer.from('blorb')
     let ipfs, hash
 
-    before(async function () {
-      // CI takes longer to instantiate the daemon, so we need to increase the
-      // timeout for the before step
-      this.timeout(60 * 1000)
-
-      ipfs = await common.setup()
+    before(async () => {
+      ipfs = (await common.spawn()).api
       const block = await ipfs.block.put(data)
       hash = block.cid.multihash
     })
 
-    after(() => common.teardown())
+    after(() => common.clean())
 
     it('should stat by CID', async () => {
       const cid = new CID(hash)

--- a/src/bootstrap/add.js
+++ b/src/bootstrap/add.js
@@ -6,10 +6,14 @@ const { getDescribe, getIt, expect } = require('../utils/mocha')
 const invalidArg = 'this/Is/So/Invalid/'
 const validIp4 = '/ip4/104.236.176.52/tcp/4001/ipfs/QmSoLnSGccFuZQJzRadHn95W2CrSFmZuTdDWP8HXaHca9z'
 
-module.exports = (createCommon, options) => {
+/** @typedef { import("ipfsd-ctl").TestsInterface } TestsInterface */
+/**
+ * @param {TestsInterface} common
+ * @param {Object} options
+ */
+module.exports = (common, options) => {
   const describe = getDescribe(options)
   const it = getIt(options)
-  const common = createCommon()
 
   describe('.bootstrap.add', function () {
     this.timeout(100 * 1000)

--- a/src/bootstrap/add.js
+++ b/src/bootstrap/add.js
@@ -6,9 +6,9 @@ const { getDescribe, getIt, expect } = require('../utils/mocha')
 const invalidArg = 'this/Is/So/Invalid/'
 const validIp4 = '/ip4/104.236.176.52/tcp/4001/ipfs/QmSoLnSGccFuZQJzRadHn95W2CrSFmZuTdDWP8HXaHca9z'
 
-/** @typedef { import("ipfsd-ctl").TestsInterface } TestsInterface */
+/** @typedef { import("ipfsd-ctl/src/factory") } Factory */
 /**
- * @param {TestsInterface} common
+ * @param {Factory} common
  * @param {Object} options
  */
 module.exports = (common, options) => {
@@ -20,15 +20,11 @@ module.exports = (common, options) => {
 
     let ipfs
 
-    before(async function () {
-      // CI takes longer to instantiate the daemon, so we need to increase the
-      // timeout for the before step
-      this.timeout(60 * 1000)
-
-      ipfs = await common.setup()
+    before(async () => {
+      ipfs = (await common.spawn()).api
     })
 
-    after(() => common.teardown())
+    after(() => common.clean())
 
     it('should return an error when called with an invalid arg', () => {
       return expect(ipfs.bootstrap.add(invalidArg)).to.eventually.be.rejected

--- a/src/bootstrap/list.js
+++ b/src/bootstrap/list.js
@@ -3,9 +3,9 @@
 
 const { getDescribe, getIt, expect } = require('../utils/mocha')
 
-/** @typedef { import("ipfsd-ctl").TestsInterface } TestsInterface */
+/** @typedef { import("ipfsd-ctl/src/factory") } Factory */
 /**
- * @param {TestsInterface} common
+ * @param {Factory} common
  * @param {Object} options
  */
 module.exports = (common, options) => {
@@ -17,9 +17,9 @@ module.exports = (common, options) => {
 
     let ipfs
 
-    before(async () => { ipfs = await common.setup() })
+    before(async () => { ipfs = (await common.spawn()).api })
 
-    after(() => common.teardown())
+    after(() => common.clean())
 
     it('should return a list of peers', async () => {
       const res = await ipfs.bootstrap.list()

--- a/src/bootstrap/list.js
+++ b/src/bootstrap/list.js
@@ -3,23 +3,21 @@
 
 const { getDescribe, getIt, expect } = require('../utils/mocha')
 
-module.exports = (createCommon, options) => {
+/** @typedef { import("ipfsd-ctl").TestsInterface } TestsInterface */
+/**
+ * @param {TestsInterface} common
+ * @param {Object} options
+ */
+module.exports = (common, options) => {
   const describe = getDescribe(options)
   const it = getIt(options)
-  const common = createCommon()
 
   describe('.bootstrap.list', function () {
     this.timeout(100 * 1000)
 
     let ipfs
 
-    before(async function () {
-      // CI takes longer to instantiate the daemon, so we need to increase the
-      // timeout for the before step
-      this.timeout(60 * 1000)
-
-      ipfs = await common.setup()
-    })
+    before(async () => { ipfs = await common.setup() })
 
     after(() => common.teardown())
 

--- a/src/bootstrap/rm.js
+++ b/src/bootstrap/rm.js
@@ -3,10 +3,14 @@
 
 const { getDescribe, getIt, expect } = require('../utils/mocha')
 
-module.exports = (createCommon, options) => {
+/** @typedef { import("ipfsd-ctl").TestsInterface } TestsInterface */
+/**
+ * @param {TestsInterface} common
+ * @param {Object} options
+ */
+module.exports = (common, options) => {
   const describe = getDescribe(options)
   const it = getIt(options)
-  const common = createCommon()
 
   const invalidArg = 'this/Is/So/Invalid/'
   const validIp4 = '/ip4/104.236.176.52/tcp/4001/ipfs/QmSoLnSGccFuZQJzRadHn95W2CrSFmZuTdDWP8HXaHca9z'
@@ -16,13 +20,7 @@ module.exports = (createCommon, options) => {
 
     let ipfs
 
-    before(async function () {
-      // CI takes longer to instantiate the daemon, so we need to increase the
-      // timeout for the before step
-      this.timeout(60 * 1000)
-
-      ipfs = await common.setup()
-    })
+    before(async () => { ipfs = await common.setup() })
 
     after(() => common.teardown())
 

--- a/src/bootstrap/rm.js
+++ b/src/bootstrap/rm.js
@@ -3,9 +3,9 @@
 
 const { getDescribe, getIt, expect } = require('../utils/mocha')
 
-/** @typedef { import("ipfsd-ctl").TestsInterface } TestsInterface */
+/** @typedef { import("ipfsd-ctl/src/factory") } Factory */
 /**
- * @param {TestsInterface} common
+ * @param {Factory} common
  * @param {Object} options
  */
 module.exports = (common, options) => {
@@ -20,9 +20,9 @@ module.exports = (common, options) => {
 
     let ipfs
 
-    before(async () => { ipfs = await common.setup() })
+    before(async () => { ipfs = (await common.spawn()).api })
 
-    after(() => common.teardown())
+    after(() => common.clean())
 
     it('should return an error when called with an invalid arg', () => {
       return expect(ipfs.bootstrap.rm(invalidArg)).to.eventually.be.rejected

--- a/src/config/get.js
+++ b/src/config/get.js
@@ -4,22 +4,20 @@
 const { getDescribe, getIt, expect } = require('../utils/mocha')
 const isPlainObject = require('is-plain-object')
 
-module.exports = (createCommon, options) => {
+/** @typedef { import("ipfsd-ctl").TestsInterface } TestsInterface */
+/**
+ * @param {TestsInterface} common
+ * @param {Object} options
+ */
+module.exports = (common, options) => {
   const describe = getDescribe(options)
   const it = getIt(options)
-  const common = createCommon()
 
   describe('.config.get', function () {
     this.timeout(30 * 1000)
     let ipfs
 
-    before(async function () {
-      // CI takes longer to instantiate the daemon, so we need to increase the
-      // timeout for the before step
-      this.timeout(60 * 1000)
-
-      ipfs = await common.setup()
-    })
+    before(async () => { ipfs = await common.setup() })
 
     after(() => common.teardown())
 

--- a/src/config/get.js
+++ b/src/config/get.js
@@ -4,9 +4,9 @@
 const { getDescribe, getIt, expect } = require('../utils/mocha')
 const isPlainObject = require('is-plain-object')
 
-/** @typedef { import("ipfsd-ctl").TestsInterface } TestsInterface */
+/** @typedef { import("ipfsd-ctl/src/factory") } Factory */
 /**
- * @param {TestsInterface} common
+ * @param {Factory} common
  * @param {Object} options
  */
 module.exports = (common, options) => {
@@ -17,9 +17,9 @@ module.exports = (common, options) => {
     this.timeout(30 * 1000)
     let ipfs
 
-    before(async () => { ipfs = await common.setup() })
+    before(async () => { ipfs = (await common.spawn()).api })
 
-    after(() => common.teardown())
+    after(() => common.clean())
 
     it('should retrieve the whole config', async () => {
       const config = await ipfs.config.get()

--- a/src/config/profiles/apply.js
+++ b/src/config/profiles/apply.js
@@ -2,9 +2,9 @@
 'use strict'
 
 const { getDescribe, getIt, expect } = require('../../utils/mocha')
-/** @typedef { import("ipfsd-ctl").TestsInterface } TestsInterface */
+/** @typedef { import("ipfsd-ctl/src/factory") } Factory */
 /**
- * @param {TestsInterface} common
+ * @param {Factory} common
  * @param {Object} options
  */
 module.exports = (common, options) => {
@@ -15,15 +15,11 @@ module.exports = (common, options) => {
     this.timeout(30 * 1000)
     let ipfs
 
-    before(async function () {
-      // CI takes longer to instantiate the daemon, so we need to increase the
-      // timeout for the before step
-      this.timeout(60 * 1000)
-
-      ipfs = await common.setup()
+    before(async () => {
+      ipfs = (await common.spawn()).api
     })
 
-    after(() => common.teardown())
+    after(() => common.clean())
 
     it('should apply a config profile', async () => {
       const diff = await ipfs.config.profiles.apply('lowpower')

--- a/src/config/profiles/apply.js
+++ b/src/config/profiles/apply.js
@@ -2,11 +2,14 @@
 'use strict'
 
 const { getDescribe, getIt, expect } = require('../../utils/mocha')
-
-module.exports = (createCommon, options) => {
+/** @typedef { import("ipfsd-ctl").TestsInterface } TestsInterface */
+/**
+ * @param {TestsInterface} common
+ * @param {Object} options
+ */
+module.exports = (common, options) => {
   const describe = getDescribe(options)
   const it = getIt(options)
-  const common = createCommon()
 
   describe('.config.profiles.apply', function () {
     this.timeout(30 * 1000)

--- a/src/config/profiles/list.js
+++ b/src/config/profiles/list.js
@@ -2,9 +2,9 @@
 'use strict'
 
 const { getDescribe, getIt, expect } = require('../../utils/mocha')
-/** @typedef { import("ipfsd-ctl").TestsInterface } TestsInterface */
+/** @typedef { import("ipfsd-ctl/src/factory") } Factory */
 /**
- * @param {TestsInterface} common
+ * @param {Factory} common
  * @param {Object} options
  */
 module.exports = (common, options) => {
@@ -15,15 +15,11 @@ module.exports = (common, options) => {
     this.timeout(30 * 1000)
     let ipfs
 
-    before(async function () {
-      // CI takes longer to instantiate the daemon, so we need to increase the
-      // timeout for the before step
-      this.timeout(60 * 1000)
-
-      ipfs = await common.setup()
+    before(async () => {
+      ipfs = (await common.spawn()).api
     })
 
-    after(() => common.teardown())
+    after(() => common.clean())
 
     it('should list config profiles', async () => {
       const profiles = await ipfs.config.profiles.list()

--- a/src/config/profiles/list.js
+++ b/src/config/profiles/list.js
@@ -2,11 +2,14 @@
 'use strict'
 
 const { getDescribe, getIt, expect } = require('../../utils/mocha')
-
-module.exports = (createCommon, options) => {
+/** @typedef { import("ipfsd-ctl").TestsInterface } TestsInterface */
+/**
+ * @param {TestsInterface} common
+ * @param {Object} options
+ */
+module.exports = (common, options) => {
   const describe = getDescribe(options)
   const it = getIt(options)
-  const common = createCommon()
 
   describe('.config.profiles.list', function () {
     this.timeout(30 * 1000)

--- a/src/config/replace.js
+++ b/src/config/replace.js
@@ -2,11 +2,14 @@
 'use strict'
 
 const { getDescribe, getIt, expect } = require('../utils/mocha')
-
-module.exports = (createCommon, options) => {
+/** @typedef { import("ipfsd-ctl").TestsInterface } TestsInterface */
+/**
+ * @param {TestsInterface} common
+ * @param {Object} options
+ */
+module.exports = (common, options) => {
   const describe = getDescribe(options)
   const it = getIt(options)
-  const common = createCommon()
 
   describe('.config.replace', function () {
     this.timeout(30 * 1000)

--- a/src/config/replace.js
+++ b/src/config/replace.js
@@ -2,9 +2,9 @@
 'use strict'
 
 const { getDescribe, getIt, expect } = require('../utils/mocha')
-/** @typedef { import("ipfsd-ctl").TestsInterface } TestsInterface */
+/** @typedef { import("ipfsd-ctl/src/factory") } Factory */
 /**
- * @param {TestsInterface} common
+ * @param {Factory} common
  * @param {Object} options
  */
 module.exports = (common, options) => {
@@ -15,15 +15,11 @@ module.exports = (common, options) => {
     this.timeout(30 * 1000)
     let ipfs
 
-    before(async function () {
-      // CI takes longer to instantiate the daemon, so we need to increase the
-      // timeout for the before step
-      this.timeout(60 * 1000)
-
-      ipfs = await common.setup()
+    before(async () => {
+      ipfs = (await common.spawn()).api
     })
 
-    after(() => common.teardown())
+    after(() => common.clean())
 
     const config = {
       Fruit: 'Bananas'

--- a/src/config/set.js
+++ b/src/config/set.js
@@ -2,11 +2,14 @@
 'use strict'
 
 const { getDescribe, getIt, expect } = require('../utils/mocha')
-
-module.exports = (createCommon, options) => {
+/** @typedef { import("ipfsd-ctl").TestsInterface } TestsInterface */
+/**
+ * @param {TestsInterface} common
+ * @param {Object} options
+ */
+module.exports = (common, options) => {
   const describe = getDescribe(options)
   const it = getIt(options)
-  const common = createCommon()
 
   describe('.config.set', function () {
     this.timeout(30 * 1000)

--- a/src/config/set.js
+++ b/src/config/set.js
@@ -2,9 +2,9 @@
 'use strict'
 
 const { getDescribe, getIt, expect } = require('../utils/mocha')
-/** @typedef { import("ipfsd-ctl").TestsInterface } TestsInterface */
+/** @typedef { import("ipfsd-ctl/src/factory") } Factory */
 /**
- * @param {TestsInterface} common
+ * @param {Factory} common
  * @param {Object} options
  */
 module.exports = (common, options) => {
@@ -15,15 +15,11 @@ module.exports = (common, options) => {
     this.timeout(30 * 1000)
     let ipfs
 
-    before(async function () {
-      // CI takes longer to instantiate the daemon, so we need to increase the
-      // timeout for the before step
-      this.timeout(60 * 1000)
-
-      ipfs = await common.setup()
+    before(async () => {
+      ipfs = (await common.spawn()).api
     })
 
-    after(() => common.teardown())
+    after(() => common.clean())
 
     it('should set a new key', async () => {
       await ipfs.config.set('Fruit', 'banana')

--- a/src/dag/get.js
+++ b/src/dag/get.js
@@ -9,21 +9,18 @@ const Unixfs = require('ipfs-unixfs')
 const CID = require('cids')
 const { getDescribe, getIt, expect } = require('../utils/mocha')
 
-module.exports = (createCommon, options) => {
+/** @typedef { import("ipfsd-ctl").TestsInterface } TestsInterface */
+/**
+ * @param {TestsInterface} common
+ * @param {Object} options
+ */
+module.exports = (common, options) => {
   const describe = getDescribe(options)
   const it = getIt(options)
-  const common = createCommon()
 
   describe('.dag.get', () => {
     let ipfs
-
-    before(async function () {
-      // CI takes longer to instantiate the daemon, so we need to increase the
-      // timeout for the before step
-      this.timeout(60 * 1000)
-
-      ipfs = await common.setup()
-    })
+    before(async () => { ipfs = await common.setup() })
 
     after(() => common.teardown())
 

--- a/src/dag/get.js
+++ b/src/dag/get.js
@@ -9,9 +9,9 @@ const Unixfs = require('ipfs-unixfs')
 const CID = require('cids')
 const { getDescribe, getIt, expect } = require('../utils/mocha')
 
-/** @typedef { import("ipfsd-ctl").TestsInterface } TestsInterface */
+/** @typedef { import("ipfsd-ctl/src/factory") } Factory */
 /**
- * @param {TestsInterface} common
+ * @param {Factory} common
  * @param {Object} options
  */
 module.exports = (common, options) => {
@@ -20,9 +20,9 @@ module.exports = (common, options) => {
 
   describe('.dag.get', () => {
     let ipfs
-    before(async () => { ipfs = await common.setup() })
+    before(async () => { ipfs = (await common.spawn()).api })
 
-    after(() => common.teardown())
+    after(() => common.clean())
 
     let pbNode
     let cborNode

--- a/src/dag/put.js
+++ b/src/dag/put.js
@@ -8,9 +8,9 @@ const CID = require('cids')
 const multihash = require('multihashes')
 const { getDescribe, getIt, expect } = require('../utils/mocha')
 
-/** @typedef { import("ipfsd-ctl").TestsInterface } TestsInterface */
+/** @typedef { import("ipfsd-ctl/src/factory") } Factory */
 /**
- * @param {TestsInterface} common
+ * @param {Factory} common
  * @param {Object} options
  */
 module.exports = (common, options) => {
@@ -20,15 +20,9 @@ module.exports = (common, options) => {
   describe('.dag.put', () => {
     let ipfs
 
-    before(async function () {
-      // CI takes longer to instantiate the daemon, so we need to increase the
-      // timeout for the before step
-      this.timeout(60 * 1000)
+    before(async () => { ipfs = (await common.spawn()).api })
 
-      ipfs = await common.setup()
-    })
-
-    after(() => common.teardown())
+    after(() => common.clean())
 
     let pbNode
     let cborNode

--- a/src/dag/put.js
+++ b/src/dag/put.js
@@ -8,10 +8,14 @@ const CID = require('cids')
 const multihash = require('multihashes')
 const { getDescribe, getIt, expect } = require('../utils/mocha')
 
-module.exports = (createCommon, options) => {
+/** @typedef { import("ipfsd-ctl").TestsInterface } TestsInterface */
+/**
+ * @param {TestsInterface} common
+ * @param {Object} options
+ */
+module.exports = (common, options) => {
   const describe = getDescribe(options)
   const it = getIt(options)
-  const common = createCommon()
 
   describe('.dag.put', () => {
     let ipfs

--- a/src/dag/tree.js
+++ b/src/dag/tree.js
@@ -7,10 +7,14 @@ const DAGNode = dagPB.DAGNode
 const dagCBOR = require('ipld-dag-cbor')
 const { getDescribe, getIt, expect } = require('../utils/mocha')
 
-module.exports = (createCommon, options) => {
+/** @typedef { import("ipfsd-ctl").TestsInterface } TestsInterface */
+/**
+ * @param {TestsInterface} common
+ * @param {Object} options
+ */
+module.exports = (common, options) => {
   const describe = getDescribe(options)
   const it = getIt(options)
-  const common = createCommon()
 
   describe('.dag.tree', () => {
     let ipfs

--- a/src/dag/tree.js
+++ b/src/dag/tree.js
@@ -7,9 +7,9 @@ const DAGNode = dagPB.DAGNode
 const dagCBOR = require('ipld-dag-cbor')
 const { getDescribe, getIt, expect } = require('../utils/mocha')
 
-/** @typedef { import("ipfsd-ctl").TestsInterface } TestsInterface */
+/** @typedef { import("ipfsd-ctl/src/factory") } Factory */
 /**
- * @param {TestsInterface} common
+ * @param {Factory} common
  * @param {Object} options
  */
 module.exports = (common, options) => {
@@ -19,15 +19,9 @@ module.exports = (common, options) => {
   describe('.dag.tree', () => {
     let ipfs
 
-    before(async function () {
-      // CI takes longer to instantiate the daemon, so we need to increase the
-      // timeout for the before step
-      this.timeout(60 * 1000)
+    before(async () => { ipfs = (await common.spawn()).api })
 
-      ipfs = await common.setup()
-    })
-
-    after(() => common.teardown())
+    after(() => common.clean())
 
     let nodePb
     let nodeCbor

--- a/src/dht/find-peer.js
+++ b/src/dht/find-peer.js
@@ -3,9 +3,9 @@
 
 const { getDescribe, getIt, expect } = require('../utils/mocha')
 
-/** @typedef { import("ipfsd-ctl").TestsInterface } TestsInterface */
+/** @typedef { import("ipfsd-ctl/src/factory") } Factory */
 /**
- * @param {TestsInterface} common
+ * @param {Factory} common
  * @param {Object} options
  */
 module.exports = (common, options) => {
@@ -18,21 +18,13 @@ module.exports = (common, options) => {
     let nodeA
     let nodeB
 
-    before(async function () {
-      // CI takes longer to instantiate the daemon, so we need to increase the
-      // timeout for the before step
-      this.timeout(60 * 1000)
-
-      nodeA = await common.setup()
-      nodeB = await common.setup()
+    before(async () => {
+      nodeA = (await common.spawn()).api
+      nodeB = (await common.spawn()).api
       await nodeB.swarm.connect(nodeA.peerId.addresses[0])
     })
 
-    after(function () {
-      this.timeout(50 * 1000)
-
-      return common.teardown()
-    })
+    after(() => common.clean())
 
     it('should find other peers', async () => {
       const res = await nodeA.dht.findPeer(nodeB.peerId.id)

--- a/src/dht/find-peer.js
+++ b/src/dht/find-peer.js
@@ -3,10 +3,14 @@
 
 const { getDescribe, getIt, expect } = require('../utils/mocha')
 
-module.exports = (createCommon, options) => {
+/** @typedef { import("ipfsd-ctl").TestsInterface } TestsInterface */
+/**
+ * @param {TestsInterface} common
+ * @param {Object} options
+ */
+module.exports = (common, options) => {
   const describe = getDescribe(options)
   const it = getIt(options)
-  const common = createCommon()
 
   describe('.dht.findPeer', function () {
     this.timeout(80 * 1000)

--- a/src/dht/find-provs.js
+++ b/src/dht/find-provs.js
@@ -22,7 +22,8 @@ module.exports = (common, options) => {
   const describe = getDescribe(options)
   const it = getIt(options)
 
-  describe('.dht.findProvs', () => {
+  describe('.dht.findProvs', function () {
+    this.timeout(20000)
     let nodeA
     let nodeB
     let nodeC

--- a/src/dht/find-provs.js
+++ b/src/dht/find-provs.js
@@ -13,9 +13,9 @@ async function fakeCid () {
   return new CID(0, 'dag-pb', mh)
 }
 
-/** @typedef { import("ipfsd-ctl").TestsInterface } TestsInterface */
+/** @typedef { import("ipfsd-ctl/src/factory") } Factory */
 /**
- * @param {TestsInterface} common
+ * @param {Factory} common
  * @param {Object} options
  */
 module.exports = (common, options) => {
@@ -28,20 +28,16 @@ module.exports = (common, options) => {
     let nodeC
 
     before(async () => {
-      nodeA = await common.setup()
-      nodeB = await common.setup()
-      nodeC = await common.setup()
+      nodeA = (await common.spawn()).api
+      nodeB = (await common.spawn()).api
+      nodeC = (await common.spawn()).api
       await Promise.all([
         nodeB.swarm.connect(nodeA.peerId.addresses[0]),
         nodeC.swarm.connect(nodeB.peerId.addresses[0])
       ])
     })
 
-    after(function () {
-      this.timeout(50 * 1000)
-
-      return common.teardown()
-    })
+    after(() => common.clean())
 
     let providedCid
     before('add providers for the same cid', async function () {

--- a/src/dht/find-provs.js
+++ b/src/dht/find-provs.js
@@ -13,21 +13,21 @@ async function fakeCid () {
   return new CID(0, 'dag-pb', mh)
 }
 
-module.exports = (createCommon, options) => {
+/** @typedef { import("ipfsd-ctl").TestsInterface } TestsInterface */
+/**
+ * @param {TestsInterface} common
+ * @param {Object} options
+ */
+module.exports = (common, options) => {
   const describe = getDescribe(options)
   const it = getIt(options)
-  const common = createCommon()
 
   describe('.dht.findProvs', () => {
     let nodeA
     let nodeB
     let nodeC
 
-    before(async function () {
-      // CI takes longer to instantiate the daemon, so we need to increase the
-      // timeout for the before step
-      this.timeout(60 * 1000)
-
+    before(async () => {
       nodeA = await common.setup()
       nodeB = await common.setup()
       nodeC = await common.setup()

--- a/src/dht/get.js
+++ b/src/dht/get.js
@@ -4,9 +4,9 @@
 const hat = require('hat')
 const { getDescribe, getIt, expect } = require('../utils/mocha')
 
-/** @typedef { import("ipfsd-ctl").TestsInterface } TestsInterface */
+/** @typedef { import("ipfsd-ctl/src/factory") } Factory */
 /**
- * @param {TestsInterface} common
+ * @param {Factory} common
  * @param {Object} options
  */
 module.exports = (common, options) => {
@@ -19,21 +19,13 @@ module.exports = (common, options) => {
     let nodeA
     let nodeB
 
-    before(async function () {
-      // CI takes longer to instantiate the daemon, so we need to increase the
-      // timeout for the before step
-      this.timeout(60 * 1000)
-
-      nodeA = await common.setup()
-      nodeB = await common.setup()
+    before(async () => {
+      nodeA = (await common.spawn()).api
+      nodeB = (await common.spawn()).api
       await nodeA.swarm.connect(nodeB.peerId.addresses[0])
     })
 
-    after(function () {
-      this.timeout(50 * 1000)
-
-      return common.teardown()
-    })
+    after(() => common.clean())
 
     it('should error when getting a non-existent key from the DHT', () => {
       return expect(nodeA.dht.get('non-existing', { timeout: 100 })).to.eventually.be.rejected

--- a/src/dht/get.js
+++ b/src/dht/get.js
@@ -4,10 +4,14 @@
 const hat = require('hat')
 const { getDescribe, getIt, expect } = require('../utils/mocha')
 
-module.exports = (createCommon, options) => {
+/** @typedef { import("ipfsd-ctl").TestsInterface } TestsInterface */
+/**
+ * @param {TestsInterface} common
+ * @param {Object} options
+ */
+module.exports = (common, options) => {
   const describe = getDescribe(options)
   const it = getIt(options)
-  const common = createCommon()
 
   describe('.dht.get', function () {
     this.timeout(80 * 1000)

--- a/src/dht/provide.js
+++ b/src/dht/provide.js
@@ -4,9 +4,9 @@
 const CID = require('cids')
 const { getDescribe, getIt, expect } = require('../utils/mocha')
 
-/** @typedef { import("ipfsd-ctl").TestsInterface } TestsInterface */
+/** @typedef { import("ipfsd-ctl/src/factory") } Factory */
 /**
- * @param {TestsInterface} common
+ * @param {Factory} common
  * @param {Object} options
  */
 module.exports = (common, options) => {
@@ -18,21 +18,13 @@ module.exports = (common, options) => {
 
     let ipfs
 
-    before(async function () {
-      // CI takes longer to instantiate the daemon, so we need to increase the
-      // timeout for the before step
-      this.timeout(60 * 1000)
-
-      ipfs = await common.setup()
-      const nodeB = await common.setup()
+    before(async () => {
+      ipfs = (await common.spawn()).api
+      const nodeB = (await common.spawn()).api
       await ipfs.swarm.connect(nodeB.peerId.addresses[0])
     })
 
-    after(function () {
-      this.timeout(50 * 1000)
-
-      return common.teardown()
-    })
+    after(() => common.clean())
 
     it('should provide local CID', async () => {
       const res = await ipfs.add(Buffer.from('test'))

--- a/src/dht/provide.js
+++ b/src/dht/provide.js
@@ -4,10 +4,14 @@
 const CID = require('cids')
 const { getDescribe, getIt, expect } = require('../utils/mocha')
 
-module.exports = (createCommon, options) => {
+/** @typedef { import("ipfsd-ctl").TestsInterface } TestsInterface */
+/**
+ * @param {TestsInterface} common
+ * @param {Object} options
+ */
+module.exports = (common, options) => {
   const describe = getDescribe(options)
   const it = getIt(options)
-  const common = createCommon()
 
   describe('.dht.provide', function () {
     this.timeout(80 * 1000)

--- a/src/dht/put.js
+++ b/src/dht/put.js
@@ -3,9 +3,9 @@
 
 const { getDescribe, getIt } = require('../utils/mocha')
 
-/** @typedef { import("ipfsd-ctl").TestsInterface } TestsInterface */
+/** @typedef { import("ipfsd-ctl/src/factory") } Factory */
 /**
- * @param {TestsInterface} common
+ * @param {Factory} common
  * @param {Object} options
  */
 module.exports = (common, options) => {
@@ -18,17 +18,13 @@ module.exports = (common, options) => {
     let nodeA
     let nodeB
 
-    before(async function () {
-      // CI takes longer to instantiate the daemon, so we need to increase the
-      // timeout for the before step
-      this.timeout(60 * 1000)
-
-      nodeA = await common.setup()
-      nodeB = await common.setup()
+    before(async () => {
+      nodeA = (await common.spawn()).api
+      nodeB = (await common.spawn()).api
       await nodeA.swarm.connect(nodeB.peerId.addresses[0])
     })
 
-    after(() => common.teardown())
+    after(() => common.clean())
 
     it('should put a value to the DHT', async function () {
       this.timeout(80 * 1000)

--- a/src/dht/put.js
+++ b/src/dht/put.js
@@ -3,10 +3,14 @@
 
 const { getDescribe, getIt } = require('../utils/mocha')
 
-module.exports = (createCommon, options) => {
+/** @typedef { import("ipfsd-ctl").TestsInterface } TestsInterface */
+/**
+ * @param {TestsInterface} common
+ * @param {Object} options
+ */
+module.exports = (common, options) => {
   const describe = getDescribe(options)
   const it = getIt(options)
-  const common = createCommon()
 
   describe('.dht.put', function () {
     this.timeout(80 * 1000)

--- a/src/dht/query.js
+++ b/src/dht/query.js
@@ -4,10 +4,14 @@
 const pTimeout = require('p-timeout')
 const { getDescribe, getIt, expect } = require('../utils/mocha')
 
-module.exports = (createCommon, options) => {
+/** @typedef { import("ipfsd-ctl").TestsInterface } TestsInterface */
+/**
+ * @param {TestsInterface} common
+ * @param {Object} options
+ */
+module.exports = (common, options) => {
   const describe = getDescribe(options)
   const it = getIt(options)
-  const common = createCommon()
 
   describe('.dht.query', function () {
     this.timeout(80 * 1000)

--- a/src/dht/query.js
+++ b/src/dht/query.js
@@ -4,9 +4,9 @@
 const pTimeout = require('p-timeout')
 const { getDescribe, getIt, expect } = require('../utils/mocha')
 
-/** @typedef { import("ipfsd-ctl").TestsInterface } TestsInterface */
+/** @typedef { import("ipfsd-ctl/src/factory") } Factory */
 /**
- * @param {TestsInterface} common
+ * @param {Factory} common
  * @param {Object} options
  */
 module.exports = (common, options) => {
@@ -19,21 +19,13 @@ module.exports = (common, options) => {
     let nodeA
     let nodeB
 
-    before(async function () {
-      // CI takes longer to instantiate the daemon, so we need to increase the
-      // timeout for the before step
-      this.timeout(60 * 1000)
-
-      nodeA = await common.setup()
-      nodeB = await common.setup()
+    before(async () => {
+      nodeA = (await common.spawn()).api
+      nodeB = (await common.spawn()).api
       await nodeB.swarm.connect(nodeA.peerId.addresses[0])
     })
 
-    after(function () {
-      this.timeout(50 * 1000)
-
-      return common.teardown()
-    })
+    after(() => common.clean())
 
     it('should return the other node in the query', async function () {
       const timeout = 150 * 1000

--- a/src/files-mfs/cp.js
+++ b/src/files-mfs/cp.js
@@ -5,9 +5,9 @@ const hat = require('hat')
 const { fixtures } = require('../files-regular/utils')
 const { getDescribe, getIt, expect } = require('../utils/mocha')
 
-/** @typedef { import("ipfsd-ctl").TestsInterface } TestsInterface */
+/** @typedef { import("ipfsd-ctl/src/factory") } Factory */
 /**
- * @param {TestsInterface} common
+ * @param {Factory} common
  * @param {Object} options
  */
 module.exports = (common, options) => {
@@ -19,15 +19,9 @@ module.exports = (common, options) => {
 
     let ipfs
 
-    before(async function () {
-      // CI takes longer to instantiate the daemon, so we need to increase the
-      // timeout for the before step
-      this.timeout(60 * 1000)
+    before(async () => { ipfs = (await common.spawn()).api })
 
-      ipfs = await common.setup()
-    })
-
-    after(() => common.teardown())
+    after(() => common.clean())
 
     it('should copy file, expect error', () => {
       const testDir = `/test-${hat()}`

--- a/src/files-mfs/cp.js
+++ b/src/files-mfs/cp.js
@@ -5,10 +5,14 @@ const hat = require('hat')
 const { fixtures } = require('../files-regular/utils')
 const { getDescribe, getIt, expect } = require('../utils/mocha')
 
-module.exports = (createCommon, options) => {
+/** @typedef { import("ipfsd-ctl").TestsInterface } TestsInterface */
+/**
+ * @param {TestsInterface} common
+ * @param {Object} options
+ */
+module.exports = (common, options) => {
   const describe = getDescribe(options)
   const it = getIt(options)
-  const common = createCommon()
 
   describe('.files.cp', function () {
     this.timeout(40 * 1000)

--- a/src/files-mfs/flush.js
+++ b/src/files-mfs/flush.js
@@ -4,9 +4,9 @@
 const hat = require('hat')
 const { getDescribe, getIt, expect } = require('../utils/mocha')
 
-/** @typedef { import("ipfsd-ctl").TestsInterface } TestsInterface */
+/** @typedef { import("ipfsd-ctl/src/factory") } Factory */
 /**
- * @param {TestsInterface} common
+ * @param {Factory} common
  * @param {Object} options
  */
 module.exports = (common, options) => {
@@ -18,15 +18,9 @@ module.exports = (common, options) => {
 
     let ipfs
 
-    before(async function () {
-      // CI takes longer to instantiate the daemon, so we need to increase the
-      // timeout for the before step
-      this.timeout(60 * 1000)
+    before(async () => { ipfs = (await common.spawn()).api })
 
-      ipfs = await common.setup()
-    })
-
-    after(() => common.teardown())
+    after(() => common.clean())
 
     it('should not flush not found file/dir, expect error', async () => {
       const testDir = `/test-${hat()}`

--- a/src/files-mfs/flush.js
+++ b/src/files-mfs/flush.js
@@ -4,10 +4,14 @@
 const hat = require('hat')
 const { getDescribe, getIt, expect } = require('../utils/mocha')
 
-module.exports = (createCommon, options) => {
+/** @typedef { import("ipfsd-ctl").TestsInterface } TestsInterface */
+/**
+ * @param {TestsInterface} common
+ * @param {Object} options
+ */
+module.exports = (common, options) => {
   const describe = getDescribe(options)
   const it = getIt(options)
-  const common = createCommon()
 
   describe('.files.flush', function () {
     this.timeout(40 * 1000)

--- a/src/files-mfs/ls-pull-stream.js
+++ b/src/files-mfs/ls-pull-stream.js
@@ -5,10 +5,14 @@ const hat = require('hat')
 const { getDescribe, getIt, expect } = require('../utils/mocha')
 const pullToPromise = require('pull-to-promise')
 
-module.exports = (createCommon, options) => {
+/** @typedef { import("ipfsd-ctl").TestsInterface } TestsInterface */
+/**
+ * @param {TestsInterface} common
+ * @param {Object} options
+ */
+module.exports = (common, options) => {
   const describe = getDescribe(options)
   const it = getIt(options)
-  const common = createCommon()
 
   describe('.files.lsPullStream', function () {
     this.timeout(40 * 1000)

--- a/src/files-mfs/ls-pull-stream.js
+++ b/src/files-mfs/ls-pull-stream.js
@@ -5,9 +5,9 @@ const hat = require('hat')
 const { getDescribe, getIt, expect } = require('../utils/mocha')
 const pullToPromise = require('pull-to-promise')
 
-/** @typedef { import("ipfsd-ctl").TestsInterface } TestsInterface */
+/** @typedef { import("ipfsd-ctl/src/factory") } Factory */
 /**
- * @param {TestsInterface} common
+ * @param {Factory} common
  * @param {Object} options
  */
 module.exports = (common, options) => {
@@ -19,15 +19,9 @@ module.exports = (common, options) => {
 
     let ipfs
 
-    before(async function () {
-      // CI takes longer to instantiate the daemon, so we need to increase the
-      // timeout for the before step
-      this.timeout(60 * 1000)
+    before(async () => { ipfs = (await common.spawn()).api })
 
-      ipfs = await common.setup()
-    })
-
-    after(() => common.teardown())
+    after(() => common.clean())
 
     it('should not ls not found file/dir, expect error', () => {
       const testDir = `/test-${hat()}`

--- a/src/files-mfs/ls-readable-stream.js
+++ b/src/files-mfs/ls-readable-stream.js
@@ -5,10 +5,14 @@ const hat = require('hat')
 const { getDescribe, getIt, expect } = require('../utils/mocha')
 const getStream = require('get-stream')
 
-module.exports = (createCommon, options) => {
+/** @typedef { import("ipfsd-ctl").TestsInterface } TestsInterface */
+/**
+ * @param {TestsInterface} common
+ * @param {Object} options
+ */
+module.exports = (common, options) => {
   const describe = getDescribe(options)
   const it = getIt(options)
-  const common = createCommon()
 
   describe('.files.lsReadableStream', function () {
     this.timeout(40 * 1000)

--- a/src/files-mfs/ls-readable-stream.js
+++ b/src/files-mfs/ls-readable-stream.js
@@ -5,9 +5,9 @@ const hat = require('hat')
 const { getDescribe, getIt, expect } = require('../utils/mocha')
 const getStream = require('get-stream')
 
-/** @typedef { import("ipfsd-ctl").TestsInterface } TestsInterface */
+/** @typedef { import("ipfsd-ctl/src/factory") } Factory */
 /**
- * @param {TestsInterface} common
+ * @param {Factory} common
  * @param {Object} options
  */
 module.exports = (common, options) => {
@@ -19,15 +19,9 @@ module.exports = (common, options) => {
 
     let ipfs
 
-    before(async function () {
-      // CI takes longer to instantiate the daemon, so we need to increase the
-      // timeout for the before step
-      this.timeout(60 * 1000)
+    before(async () => { ipfs = (await common.spawn()).api })
 
-      ipfs = await common.setup()
-    })
-
-    after(() => common.teardown())
+    after(() => common.clean())
 
     it('should not ls not found file/dir, expect error', () => {
       const testDir = `/test-${hat()}`

--- a/src/files-mfs/ls.js
+++ b/src/files-mfs/ls.js
@@ -5,9 +5,9 @@ const hat = require('hat')
 const { fixtures } = require('../files-regular/utils')
 const { getDescribe, getIt, expect } = require('../utils/mocha')
 
-/** @typedef { import("ipfsd-ctl").TestsInterface } TestsInterface */
+/** @typedef { import("ipfsd-ctl/src/factory") } Factory */
 /**
- * @param {TestsInterface} common
+ * @param {Factory} common
  * @param {Object} options
  */
 module.exports = (common, options) => {
@@ -19,15 +19,9 @@ module.exports = (common, options) => {
 
     let ipfs
 
-    before(async function () {
-      // CI takes longer to instantiate the daemon, so we need to increase the
-      // timeout for the before step
-      this.timeout(60 * 1000)
+    before(async () => { ipfs = (await common.spawn()).api })
 
-      ipfs = await common.setup()
-    })
-
-    after(() => common.teardown())
+    after(() => common.clean())
 
     it('should not ls not found file/dir, expect error', () => {
       const testDir = `/test-${hat()}`

--- a/src/files-mfs/ls.js
+++ b/src/files-mfs/ls.js
@@ -5,10 +5,14 @@ const hat = require('hat')
 const { fixtures } = require('../files-regular/utils')
 const { getDescribe, getIt, expect } = require('../utils/mocha')
 
-module.exports = (createCommon, options) => {
+/** @typedef { import("ipfsd-ctl").TestsInterface } TestsInterface */
+/**
+ * @param {TestsInterface} common
+ * @param {Object} options
+ */
+module.exports = (common, options) => {
   const describe = getDescribe(options)
   const it = getIt(options)
-  const common = createCommon()
 
   describe('.files.ls', function () {
     this.timeout(40 * 1000)

--- a/src/files-mfs/mkdir.js
+++ b/src/files-mfs/mkdir.js
@@ -4,10 +4,14 @@
 const hat = require('hat')
 const { getDescribe, getIt, expect } = require('../utils/mocha')
 
-module.exports = (createCommon, options) => {
+/** @typedef { import("ipfsd-ctl").TestsInterface } TestsInterface */
+/**
+ * @param {TestsInterface} common
+ * @param {Object} options
+ */
+module.exports = (common, options) => {
   const describe = getDescribe(options)
   const it = getIt(options)
-  const common = createCommon()
 
   describe('.files.mkdir', function () {
     this.timeout(40 * 1000)

--- a/src/files-mfs/mkdir.js
+++ b/src/files-mfs/mkdir.js
@@ -4,9 +4,9 @@
 const hat = require('hat')
 const { getDescribe, getIt, expect } = require('../utils/mocha')
 
-/** @typedef { import("ipfsd-ctl").TestsInterface } TestsInterface */
+/** @typedef { import("ipfsd-ctl/src/factory") } Factory */
 /**
- * @param {TestsInterface} common
+ * @param {Factory} common
  * @param {Object} options
  */
 module.exports = (common, options) => {
@@ -18,15 +18,9 @@ module.exports = (common, options) => {
 
     let ipfs
 
-    before(async function () {
-      // CI takes longer to instantiate the daemon, so we need to increase the
-      // timeout for the before step
-      this.timeout(60 * 1000)
+    before(async () => { ipfs = (await common.spawn()).api })
 
-      ipfs = await common.setup()
-    })
-
-    after(() => common.teardown())
+    after(() => common.clean())
 
     it('should make directory on root', () => {
       const testDir = `/test-${hat()}`

--- a/src/files-mfs/mv.js
+++ b/src/files-mfs/mv.js
@@ -4,10 +4,14 @@
 const hat = require('hat')
 const { getDescribe, getIt, expect } = require('../utils/mocha')
 
-module.exports = (createCommon, options) => {
+/** @typedef { import("ipfsd-ctl").TestsInterface } TestsInterface */
+/**
+ * @param {TestsInterface} common
+ * @param {Object} options
+ */
+module.exports = (common, options) => {
   const describe = getDescribe(options)
   const it = getIt(options)
-  const common = createCommon()
 
   describe('.files.mv', function () {
     this.timeout(40 * 1000)

--- a/src/files-mfs/mv.js
+++ b/src/files-mfs/mv.js
@@ -4,9 +4,9 @@
 const hat = require('hat')
 const { getDescribe, getIt, expect } = require('../utils/mocha')
 
-/** @typedef { import("ipfsd-ctl").TestsInterface } TestsInterface */
+/** @typedef { import("ipfsd-ctl/src/factory") } Factory */
 /**
- * @param {TestsInterface} common
+ * @param {Factory} common
  * @param {Object} options
  */
 module.exports = (common, options) => {
@@ -18,19 +18,13 @@ module.exports = (common, options) => {
 
     let ipfs
 
-    before(async function () {
-      // CI takes longer to instantiate the daemon, so we need to increase the
-      // timeout for the before step
-      this.timeout(60 * 1000)
-
-      ipfs = await common.setup()
-    })
+    before(async () => { ipfs = (await common.spawn()).api })
 
     before(async () => {
       await ipfs.files.mkdir('/test/lv1/lv2', { parents: true })
       await ipfs.files.write('/test/a', Buffer.from('Hello, world!'), { create: true })
     })
-    after(() => common.teardown())
+    after(() => common.clean())
 
     it('should not move not found file/dir, expect error', () => {
       const testDir = `/test-${hat()}`

--- a/src/files-mfs/read-pull-stream.js
+++ b/src/files-mfs/read-pull-stream.js
@@ -5,9 +5,9 @@ const hat = require('hat')
 const { getDescribe, getIt, expect } = require('../utils/mocha')
 const pullToPromise = require('pull-to-promise')
 
-/** @typedef { import("ipfsd-ctl").TestsInterface } TestsInterface */
+/** @typedef { import("ipfsd-ctl/src/factory") } Factory */
 /**
- * @param {TestsInterface} common
+ * @param {Factory} common
  * @param {Object} options
  */
 module.exports = (common, options) => {
@@ -19,15 +19,9 @@ module.exports = (common, options) => {
 
     let ipfs
 
-    before(async function () {
-      // CI takes longer to instantiate the daemon, so we need to increase the
-      // timeout for the before step
-      this.timeout(60 * 1000)
+    before(async () => { ipfs = (await common.spawn()).api })
 
-      ipfs = await common.setup()
-    })
-
-    after(() => common.teardown())
+    after(() => common.clean())
 
     it('should not read not found, expect error', () => {
       const testDir = `/test-${hat()}`

--- a/src/files-mfs/read-pull-stream.js
+++ b/src/files-mfs/read-pull-stream.js
@@ -5,10 +5,14 @@ const hat = require('hat')
 const { getDescribe, getIt, expect } = require('../utils/mocha')
 const pullToPromise = require('pull-to-promise')
 
-module.exports = (createCommon, options) => {
+/** @typedef { import("ipfsd-ctl").TestsInterface } TestsInterface */
+/**
+ * @param {TestsInterface} common
+ * @param {Object} options
+ */
+module.exports = (common, options) => {
   const describe = getDescribe(options)
   const it = getIt(options)
-  const common = createCommon()
 
   describe('.files.readPullStream', function () {
     this.timeout(40 * 1000)

--- a/src/files-mfs/read-readable-stream.js
+++ b/src/files-mfs/read-readable-stream.js
@@ -5,9 +5,9 @@ const hat = require('hat')
 const { getDescribe, getIt, expect } = require('../utils/mocha')
 const getStream = require('get-stream')
 
-/** @typedef { import("ipfsd-ctl").TestsInterface } TestsInterface */
+/** @typedef { import("ipfsd-ctl/src/factory") } Factory */
 /**
- * @param {TestsInterface} common
+ * @param {Factory} common
  * @param {Object} options
  */
 module.exports = (common, options) => {
@@ -19,15 +19,9 @@ module.exports = (common, options) => {
 
     let ipfs
 
-    before(async function () {
-      // CI takes longer to instantiate the daemon, so we need to increase the
-      // timeout for the before step
-      this.timeout(60 * 1000)
+    before(async () => { ipfs = (await common.spawn()).api })
 
-      ipfs = await common.setup()
-    })
-
-    after(() => common.teardown())
+    after(() => common.clean())
 
     it('should not read not found, expect error', () => {
       const testDir = `/test-${hat()}`

--- a/src/files-mfs/read-readable-stream.js
+++ b/src/files-mfs/read-readable-stream.js
@@ -5,10 +5,14 @@ const hat = require('hat')
 const { getDescribe, getIt, expect } = require('../utils/mocha')
 const getStream = require('get-stream')
 
-module.exports = (createCommon, options) => {
+/** @typedef { import("ipfsd-ctl").TestsInterface } TestsInterface */
+/**
+ * @param {TestsInterface} common
+ * @param {Object} options
+ */
+module.exports = (common, options) => {
   const describe = getDescribe(options)
   const it = getIt(options)
-  const common = createCommon()
 
   describe('.files.readReadableStream', function () {
     this.timeout(40 * 1000)

--- a/src/files-mfs/read.js
+++ b/src/files-mfs/read.js
@@ -5,10 +5,14 @@ const hat = require('hat')
 const { fixtures } = require('../files-regular/utils')
 const { getDescribe, getIt, expect } = require('../utils/mocha')
 
-module.exports = (createCommon, options) => {
+/** @typedef { import("ipfsd-ctl").TestsInterface } TestsInterface */
+/**
+ * @param {TestsInterface} common
+ * @param {Object} options
+ */
+module.exports = (common, options) => {
   const describe = getDescribe(options)
   const it = getIt(options)
-  const common = createCommon()
 
   describe('.files.read', function () {
     this.timeout(40 * 1000)

--- a/src/files-mfs/read.js
+++ b/src/files-mfs/read.js
@@ -5,9 +5,9 @@ const hat = require('hat')
 const { fixtures } = require('../files-regular/utils')
 const { getDescribe, getIt, expect } = require('../utils/mocha')
 
-/** @typedef { import("ipfsd-ctl").TestsInterface } TestsInterface */
+/** @typedef { import("ipfsd-ctl/src/factory") } Factory */
 /**
- * @param {TestsInterface} common
+ * @param {Factory} common
  * @param {Object} options
  */
 module.exports = (common, options) => {
@@ -19,15 +19,9 @@ module.exports = (common, options) => {
 
     let ipfs
 
-    before(async function () {
-      // CI takes longer to instantiate the daemon, so we need to increase the
-      // timeout for the before step
-      this.timeout(60 * 1000)
+    before(async () => { ipfs = (await common.spawn()).api })
 
-      ipfs = await common.setup()
-    })
-
-    after(() => common.teardown())
+    after(() => common.clean())
 
     it('should not read not found, expect error', () => {
       const testDir = `/test-${hat()}`

--- a/src/files-mfs/rm.js
+++ b/src/files-mfs/rm.js
@@ -4,10 +4,14 @@
 const hat = require('hat')
 const { getDescribe, getIt, expect } = require('../utils/mocha')
 
-module.exports = (createCommon, options) => {
+/** @typedef { import("ipfsd-ctl").TestsInterface } TestsInterface */
+/**
+ * @param {TestsInterface} common
+ * @param {Object} options
+ */
+module.exports = (common, options) => {
   const describe = getDescribe(options)
   const it = getIt(options)
-  const common = createCommon()
 
   describe('.files.rm', function () {
     this.timeout(40 * 1000)

--- a/src/files-mfs/rm.js
+++ b/src/files-mfs/rm.js
@@ -4,9 +4,9 @@
 const hat = require('hat')
 const { getDescribe, getIt, expect } = require('../utils/mocha')
 
-/** @typedef { import("ipfsd-ctl").TestsInterface } TestsInterface */
+/** @typedef { import("ipfsd-ctl/src/factory") } Factory */
 /**
- * @param {TestsInterface} common
+ * @param {Factory} common
  * @param {Object} options
  */
 module.exports = (common, options) => {
@@ -18,15 +18,9 @@ module.exports = (common, options) => {
 
     let ipfs
 
-    before(async function () {
-      // CI takes longer to instantiate the daemon, so we need to increase the
-      // timeout for the before step
-      this.timeout(60 * 1000)
+    before(async () => { ipfs = (await common.spawn()).api })
 
-      ipfs = await common.setup()
-    })
-
-    after(() => common.teardown())
+    after(() => common.clean())
 
     it('should not remove not found file/dir, expect error', () => {
       const testDir = `/test-${hat()}`

--- a/src/files-mfs/stat.js
+++ b/src/files-mfs/stat.js
@@ -5,9 +5,9 @@ const hat = require('hat')
 const { fixtures } = require('../files-regular/utils')
 const { getDescribe, getIt, expect } = require('../utils/mocha')
 
-/** @typedef { import("ipfsd-ctl").TestsInterface } TestsInterface */
+/** @typedef { import("ipfsd-ctl/src/factory") } Factory */
 /**
- * @param {TestsInterface} common
+ * @param {Factory} common
  * @param {Object} options
  */
 module.exports = (common, options) => {
@@ -19,16 +19,10 @@ module.exports = (common, options) => {
 
     let ipfs
 
-    before(async function () {
-      // CI takes longer to instantiate the daemon, so we need to increase the
-      // timeout for the before step
-      this.timeout(60 * 1000)
-
-      ipfs = await common.setup()
-    })
+    before(async () => { ipfs = (await common.spawn()).api })
     before(async () => { await ipfs.add(fixtures.smallFile.data) })
 
-    after(() => common.teardown())
+    after(() => common.clean())
 
     it('should not stat not found file/dir, expect error', function () {
       const testDir = `/test-${hat()}`

--- a/src/files-mfs/stat.js
+++ b/src/files-mfs/stat.js
@@ -5,10 +5,14 @@ const hat = require('hat')
 const { fixtures } = require('../files-regular/utils')
 const { getDescribe, getIt, expect } = require('../utils/mocha')
 
-module.exports = (createCommon, options) => {
+/** @typedef { import("ipfsd-ctl").TestsInterface } TestsInterface */
+/**
+ * @param {TestsInterface} common
+ * @param {Object} options
+ */
+module.exports = (common, options) => {
   const describe = getDescribe(options)
   const it = getIt(options)
-  const common = createCommon()
 
   describe('.files.stat', function () {
     this.timeout(40 * 1000)

--- a/src/files-mfs/write.js
+++ b/src/files-mfs/write.js
@@ -4,9 +4,9 @@
 const hat = require('hat')
 const { getDescribe, getIt, expect } = require('../utils/mocha')
 
-/** @typedef { import("ipfsd-ctl").TestsInterface } TestsInterface */
+/** @typedef { import("ipfsd-ctl/src/factory") } Factory */
 /**
- * @param {TestsInterface} common
+ * @param {Factory} common
  * @param {Object} options
  */
 module.exports = (common, options) => {
@@ -18,15 +18,9 @@ module.exports = (common, options) => {
 
     let ipfs
 
-    before(async function () {
-      // CI takes longer to instantiate the daemon, so we need to increase the
-      // timeout for the before step
-      this.timeout(60 * 1000)
+    before(async () => { ipfs = (await common.spawn()).api })
 
-      ipfs = await common.setup()
-    })
-
-    after(() => common.teardown())
+    after(() => common.clean())
 
     it('should not write to non existent file, expect error', function () {
       const testDir = `/test-${hat()}`

--- a/src/files-mfs/write.js
+++ b/src/files-mfs/write.js
@@ -4,10 +4,14 @@
 const hat = require('hat')
 const { getDescribe, getIt, expect } = require('../utils/mocha')
 
-module.exports = (createCommon, options) => {
+/** @typedef { import("ipfsd-ctl").TestsInterface } TestsInterface */
+/**
+ * @param {TestsInterface} common
+ * @param {Object} options
+ */
+module.exports = (common, options) => {
   const describe = getDescribe(options)
   const it = getIt(options)
-  const common = createCommon()
 
   describe('.files.write', function () {
     this.timeout(40 * 1000)

--- a/src/files-regular/add-from-fs.js
+++ b/src/files-regular/add-from-fs.js
@@ -7,10 +7,14 @@ const { getDescribe, getIt, expect } = require('../utils/mocha')
 const fs = require('fs')
 const os = require('os')
 
-module.exports = (createCommon, options) => {
+/** @typedef { import("ipfsd-ctl").TestsInterface } TestsInterface */
+/**
+ * @param {TestsInterface} common
+ * @param {Object} options
+ */
+module.exports = (common, options) => {
   const describe = getDescribe(options)
   const it = getIt(options)
-  const common = createCommon()
 
   describe('.addFromFs', function () {
     this.timeout(40 * 1000)

--- a/src/files-regular/add-from-fs.js
+++ b/src/files-regular/add-from-fs.js
@@ -7,9 +7,9 @@ const { getDescribe, getIt, expect } = require('../utils/mocha')
 const fs = require('fs')
 const os = require('os')
 
-/** @typedef { import("ipfsd-ctl").TestsInterface } TestsInterface */
+/** @typedef { import("ipfsd-ctl/src/factory") } Factory */
 /**
- * @param {TestsInterface} common
+ * @param {Factory} common
  * @param {Object} options
  */
 module.exports = (common, options) => {
@@ -22,15 +22,9 @@ module.exports = (common, options) => {
     const fixturesPath = path.join(__dirname, '../../test/fixtures')
     let ipfs
 
-    before(async function () {
-      // CI takes longer to instantiate the daemon, so we need to increase the
-      // timeout for the before step
-      this.timeout(60 * 1000)
+    before(async () => { ipfs = (await common.spawn()).api })
 
-      ipfs = await common.setup()
-    })
-
-    after(() => common.teardown())
+    after(() => common.clean())
 
     it('should add a directory from the file system', async () => {
       const filesPath = path.join(fixturesPath, 'test-folder')

--- a/src/files-regular/add-from-stream.js
+++ b/src/files-regular/add-from-stream.js
@@ -5,9 +5,9 @@ const { Readable } = require('readable-stream')
 const { getDescribe, getIt, expect } = require('../utils/mocha')
 const { fixtures } = require('./utils')
 
-/** @typedef { import("ipfsd-ctl").TestsInterface } TestsInterface */
+/** @typedef { import("ipfsd-ctl/src/factory") } Factory */
 /**
- * @param {TestsInterface} common
+ * @param {Factory} common
  * @param {Object} options
  */
 module.exports = (common, options) => {
@@ -19,15 +19,9 @@ module.exports = (common, options) => {
 
     let ipfs
 
-    before(async function () {
-      // CI takes longer to instantiate the daemon, so we need to increase the
-      // timeout for the before step
-      this.timeout(60 * 1000)
+    before(async () => { ipfs = (await common.spawn()).api })
 
-      ipfs = await common.setup()
-    })
-
-    after(() => common.teardown())
+    after(() => common.clean())
 
     it('should add from a stream', async () => {
       const stream = new Readable({

--- a/src/files-regular/add-from-stream.js
+++ b/src/files-regular/add-from-stream.js
@@ -5,10 +5,14 @@ const { Readable } = require('readable-stream')
 const { getDescribe, getIt, expect } = require('../utils/mocha')
 const { fixtures } = require('./utils')
 
-module.exports = (createCommon, options) => {
+/** @typedef { import("ipfsd-ctl").TestsInterface } TestsInterface */
+/**
+ * @param {TestsInterface} common
+ * @param {Object} options
+ */
+module.exports = (common, options) => {
   const describe = getDescribe(options)
   const it = getIt(options)
-  const common = createCommon()
 
   describe('.addFromStream', function () {
     this.timeout(40 * 1000)

--- a/src/files-regular/add-from-url.js
+++ b/src/files-regular/add-from-url.js
@@ -5,10 +5,14 @@ const pTimeout = require('p-timeout')
 const { getDescribe, getIt, expect } = require('../utils/mocha')
 const { echoUrl, redirectUrl } = require('../utils/echo-http-server')
 
-module.exports = (createCommon, options) => {
+/** @typedef { import("ipfsd-ctl").TestsInterface } TestsInterface */
+/**
+ * @param {TestsInterface} common
+ * @param {Object} options
+ */
+module.exports = (common, options) => {
   const describe = getDescribe(options)
   const it = getIt(options)
-  const common = createCommon()
 
   describe('.addFromURL', function () {
     this.timeout(40 * 1000)

--- a/src/files-regular/add-from-url.js
+++ b/src/files-regular/add-from-url.js
@@ -5,9 +5,9 @@ const pTimeout = require('p-timeout')
 const { getDescribe, getIt, expect } = require('../utils/mocha')
 const { echoUrl, redirectUrl } = require('../utils/echo-http-server')
 
-/** @typedef { import("ipfsd-ctl").TestsInterface } TestsInterface */
+/** @typedef { import("ipfsd-ctl/src/factory") } Factory */
 /**
- * @param {TestsInterface} common
+ * @param {Factory} common
  * @param {Object} options
  */
 module.exports = (common, options) => {
@@ -19,15 +19,9 @@ module.exports = (common, options) => {
 
     let ipfs
 
-    before(async function () {
-      // CI takes longer to instantiate the daemon, so we need to increase the
-      // timeout for the before step
-      this.timeout(60 * 1000)
+    before(async () => { ipfs = (await common.spawn()).api })
 
-      ipfs = await common.setup()
-    })
-
-    after(() => common.teardown())
+    after(() => common.clean())
 
     it('should add from a HTTP URL', async () => {
       const text = `TEST${Date.now()}`

--- a/src/files-regular/add-pull-stream.js
+++ b/src/files-regular/add-pull-stream.js
@@ -6,9 +6,9 @@ const pull = require('pull-stream')
 const { getDescribe, getIt, expect } = require('../utils/mocha')
 const pullToPromise = require('pull-to-promise')
 
-/** @typedef { import("ipfsd-ctl").TestsInterface } TestsInterface */
+/** @typedef { import("ipfsd-ctl/src/factory") } Factory */
 /**
- * @param {TestsInterface} common
+ * @param {Factory} common
  * @param {Object} options
  */
 module.exports = (common, options) => {
@@ -20,15 +20,9 @@ module.exports = (common, options) => {
 
     let ipfs
 
-    before(async function () {
-      // CI takes longer to instantiate the daemon, so we need to increase the
-      // timeout for the before step
-      this.timeout(60 * 1000)
+    before(async () => { ipfs = (await common.spawn()).api })
 
-      ipfs = await common.setup()
-    })
-
-    after(() => common.teardown())
+    after(() => common.clean())
 
     it('should add pull stream of valid files and dirs', async function () {
       const content = (name) => ({

--- a/src/files-regular/add-pull-stream.js
+++ b/src/files-regular/add-pull-stream.js
@@ -6,10 +6,14 @@ const pull = require('pull-stream')
 const { getDescribe, getIt, expect } = require('../utils/mocha')
 const pullToPromise = require('pull-to-promise')
 
-module.exports = (createCommon, options) => {
+/** @typedef { import("ipfsd-ctl").TestsInterface } TestsInterface */
+/**
+ * @param {TestsInterface} common
+ * @param {Object} options
+ */
+module.exports = (common, options) => {
   const describe = getDescribe(options)
   const it = getIt(options)
-  const common = createCommon()
 
   describe('.addPullStream', function () {
     this.timeout(40 * 1000)

--- a/src/files-regular/add-readable-stream.js
+++ b/src/files-regular/add-readable-stream.js
@@ -5,10 +5,14 @@ const { fixtures } = require('./utils')
 const { getDescribe, getIt, expect } = require('../utils/mocha')
 const getStream = require('get-stream')
 
-module.exports = (createCommon, options) => {
+/** @typedef { import("ipfsd-ctl").TestsInterface } TestsInterface */
+/**
+ * @param {TestsInterface} common
+ * @param {Object} options
+ */
+module.exports = (common, options) => {
   const describe = getDescribe(options)
   const it = getIt(options)
-  const common = createCommon()
 
   describe('.addReadableStream', function () {
     this.timeout(40 * 1000)

--- a/src/files-regular/add-readable-stream.js
+++ b/src/files-regular/add-readable-stream.js
@@ -5,9 +5,9 @@ const { fixtures } = require('./utils')
 const { getDescribe, getIt, expect } = require('../utils/mocha')
 const getStream = require('get-stream')
 
-/** @typedef { import("ipfsd-ctl").TestsInterface } TestsInterface */
+/** @typedef { import("ipfsd-ctl/src/factory") } Factory */
 /**
- * @param {TestsInterface} common
+ * @param {Factory} common
  * @param {Object} options
  */
 module.exports = (common, options) => {
@@ -19,15 +19,9 @@ module.exports = (common, options) => {
 
     let ipfs
 
-    before(async function () {
-      // CI takes longer to instantiate the daemon, so we need to increase the
-      // timeout for the before step
-      this.timeout(60 * 1000)
+    before(async () => { ipfs = (await common.spawn()).api })
 
-      ipfs = await common.setup()
-    })
-
-    after(() => common.teardown())
+    after(() => common.clean())
 
     it('should add readable stream of valid files and dirs', async function () {
       const content = (name) => ({

--- a/src/files-regular/add.js
+++ b/src/files-regular/add.js
@@ -8,10 +8,14 @@ const expectTimeout = require('../utils/expect-timeout')
 const { getDescribe, getIt, expect } = require('../utils/mocha')
 const { supportsFileReader } = require('ipfs-utils/src/supports')
 
-module.exports = (createCommon, options) => {
+/** @typedef { import("ipfsd-ctl").TestsInterface } TestsInterface */
+/**
+ * @param {TestsInterface} common
+ * @param {Object} options
+ */
+module.exports = (common, options) => {
   const describe = getDescribe(options)
   const it = getIt(options)
-  const common = createCommon()
 
   describe('.add', function () {
     this.timeout(40 * 1000)

--- a/src/files-regular/add.js
+++ b/src/files-regular/add.js
@@ -8,9 +8,9 @@ const expectTimeout = require('../utils/expect-timeout')
 const { getDescribe, getIt, expect } = require('../utils/mocha')
 const { supportsFileReader } = require('ipfs-utils/src/supports')
 
-/** @typedef { import("ipfsd-ctl").TestsInterface } TestsInterface */
+/** @typedef { import("ipfsd-ctl/src/factory") } Factory */
 /**
- * @param {TestsInterface} common
+ * @param {Factory} common
  * @param {Object} options
  */
 module.exports = (common, options) => {
@@ -22,15 +22,9 @@ module.exports = (common, options) => {
 
     let ipfs
 
-    before(async function () {
-      // CI takes longer to instantiate the daemon, so we need to increase the
-      // timeout for the before step
-      this.timeout(60 * 1000)
+    before(async () => { ipfs = (await common.spawn()).api })
 
-      ipfs = await common.setup()
-    })
-
-    after(() => common.teardown())
+    after(() => common.clean())
 
     it('should add a File', async function () {
       if (!supportsFileReader) return this.skip('skip in node')

--- a/src/files-regular/cat-pull-stream.js
+++ b/src/files-regular/cat-pull-stream.js
@@ -5,10 +5,14 @@ const { fixtures } = require('./utils')
 const { getDescribe, getIt, expect } = require('../utils/mocha')
 const pullToPromise = require('pull-to-promise')
 
-module.exports = (createCommon, options) => {
+/** @typedef { import("ipfsd-ctl").TestsInterface } TestsInterface */
+/**
+ * @param {TestsInterface} common
+ * @param {Object} options
+ */
+module.exports = (common, options) => {
   const describe = getDescribe(options)
   const it = getIt(options)
-  const common = createCommon()
 
   describe('.catPullStream', function () {
     this.timeout(40 * 1000)

--- a/src/files-regular/cat-pull-stream.js
+++ b/src/files-regular/cat-pull-stream.js
@@ -5,9 +5,9 @@ const { fixtures } = require('./utils')
 const { getDescribe, getIt, expect } = require('../utils/mocha')
 const pullToPromise = require('pull-to-promise')
 
-/** @typedef { import("ipfsd-ctl").TestsInterface } TestsInterface */
+/** @typedef { import("ipfsd-ctl/src/factory") } Factory */
 /**
- * @param {TestsInterface} common
+ * @param {Factory} common
  * @param {Object} options
  */
 module.exports = (common, options) => {
@@ -19,16 +19,10 @@ module.exports = (common, options) => {
 
     let ipfs
 
-    before(async function () {
-      // CI takes longer to instantiate the daemon, so we need to increase the
-      // timeout for the before step
-      this.timeout(60 * 1000)
-
-      ipfs = await common.setup()
-    })
+    before(async () => { ipfs = (await common.spawn()).api })
 
     before(() => ipfs.add(fixtures.smallFile.data))
-    after(() => common.teardown())
+    after(() => common.clean())
 
     it('should return a Pull Stream for a CID', async () => {
       const stream = ipfs.catPullStream(fixtures.smallFile.cid)

--- a/src/files-regular/cat-readable-stream.js
+++ b/src/files-regular/cat-readable-stream.js
@@ -5,10 +5,14 @@ const { fixtures } = require('./utils')
 const { getDescribe, getIt, expect } = require('../utils/mocha')
 const getStream = require('get-stream')
 
-module.exports = (createCommon, options) => {
+/** @typedef { import("ipfsd-ctl").TestsInterface } TestsInterface */
+/**
+ * @param {TestsInterface} common
+ * @param {Object} options
+ */
+module.exports = (common, options) => {
   const describe = getDescribe(options)
   const it = getIt(options)
-  const common = createCommon()
 
   describe('.catReadableStream', function () {
     this.timeout(40 * 1000)

--- a/src/files-regular/cat-readable-stream.js
+++ b/src/files-regular/cat-readable-stream.js
@@ -5,9 +5,9 @@ const { fixtures } = require('./utils')
 const { getDescribe, getIt, expect } = require('../utils/mocha')
 const getStream = require('get-stream')
 
-/** @typedef { import("ipfsd-ctl").TestsInterface } TestsInterface */
+/** @typedef { import("ipfsd-ctl/src/factory") } Factory */
 /**
- * @param {TestsInterface} common
+ * @param {Factory} common
  * @param {Object} options
  */
 module.exports = (common, options) => {
@@ -19,17 +19,13 @@ module.exports = (common, options) => {
 
     let ipfs
 
-    before(async function () {
-      // CI takes longer to instantiate the daemon, so we need to increase the
-      // timeout for the before step
-      this.timeout(60 * 1000)
-
-      ipfs = await common.setup()
+    before(async () => {
+      ipfs = (await common.spawn()).api
       await ipfs.add(fixtures.bigFile.data)
       await ipfs.add(fixtures.smallFile.data)
     })
 
-    after(() => common.teardown())
+    after(() => common.clean())
 
     it('should return a Readable Stream for a CID', async () => {
       const stream = ipfs.catReadableStream(fixtures.bigFile.cid)

--- a/src/files-regular/cat.js
+++ b/src/files-regular/cat.js
@@ -6,10 +6,14 @@ const bs58 = require('bs58')
 const CID = require('cids')
 const { getDescribe, getIt, expect } = require('../utils/mocha')
 
-module.exports = (createCommon, options) => {
+/** @typedef { import("ipfsd-ctl").TestsInterface } TestsInterface */
+/**
+ * @param {TestsInterface} common
+ * @param {Object} options
+ */
+module.exports = (common, options) => {
   const describe = getDescribe(options)
   const it = getIt(options)
-  const common = createCommon()
 
   describe('.cat', function () {
     this.timeout(40 * 1000)

--- a/src/files-regular/cat.js
+++ b/src/files-regular/cat.js
@@ -6,9 +6,9 @@ const bs58 = require('bs58')
 const CID = require('cids')
 const { getDescribe, getIt, expect } = require('../utils/mocha')
 
-/** @typedef { import("ipfsd-ctl").TestsInterface } TestsInterface */
+/** @typedef { import("ipfsd-ctl/src/factory") } Factory */
 /**
- * @param {TestsInterface} common
+ * @param {Factory} common
  * @param {Object} options
  */
 module.exports = (common, options) => {
@@ -20,15 +20,9 @@ module.exports = (common, options) => {
 
     let ipfs
 
-    before(async function () {
-      // CI takes longer to instantiate the daemon, so we need to increase the
-      // timeout for the before step
-      this.timeout(60 * 1000)
+    before(async () => { ipfs = (await common.spawn()).api })
 
-      ipfs = await common.setup()
-    })
-
-    after(() => common.teardown())
+    after(() => common.clean())
 
     before(() => Promise.all([
       ipfs.add(fixtures.smallFile.data),

--- a/src/files-regular/get-pull-stream.js
+++ b/src/files-regular/get-pull-stream.js
@@ -5,10 +5,14 @@ const { fixtures } = require('./utils')
 const { getDescribe, getIt, expect } = require('../utils/mocha')
 const pullToPromise = require('pull-to-promise')
 
-module.exports = (createCommon, options) => {
+/** @typedef { import("ipfsd-ctl").TestsInterface } TestsInterface */
+/**
+ * @param {TestsInterface} common
+ * @param {Object} options
+ */
+module.exports = (common, options) => {
   const describe = getDescribe(options)
   const it = getIt(options)
-  const common = createCommon()
 
   describe('.getPullStream', function () {
     this.timeout(40 * 1000)

--- a/src/files-regular/get-pull-stream.js
+++ b/src/files-regular/get-pull-stream.js
@@ -5,9 +5,9 @@ const { fixtures } = require('./utils')
 const { getDescribe, getIt, expect } = require('../utils/mocha')
 const pullToPromise = require('pull-to-promise')
 
-/** @typedef { import("ipfsd-ctl").TestsInterface } TestsInterface */
+/** @typedef { import("ipfsd-ctl/src/factory") } Factory */
 /**
- * @param {TestsInterface} common
+ * @param {Factory} common
  * @param {Object} options
  */
 module.exports = (common, options) => {
@@ -19,17 +19,11 @@ module.exports = (common, options) => {
 
     let ipfs
 
-    before(async function () {
-      // CI takes longer to instantiate the daemon, so we need to increase the
-      // timeout for the before step
-      this.timeout(60 * 1000)
-
-      ipfs = await common.setup()
-    })
+    before(async () => { ipfs = (await common.spawn()).api })
 
     before(() => ipfs.add(fixtures.smallFile.data))
 
-    after(() => common.teardown())
+    after(() => common.clean())
 
     it('should return a Pull Stream of Pull Streams', async () => {
       const stream = ipfs.getPullStream(fixtures.smallFile.cid)

--- a/src/files-regular/get-readable-stream.js
+++ b/src/files-regular/get-readable-stream.js
@@ -6,9 +6,9 @@ const through = require('through2')
 const { getDescribe, getIt, expect } = require('../utils/mocha')
 const getStream = require('get-stream')
 
-/** @typedef { import("ipfsd-ctl").TestsInterface } TestsInterface */
+/** @typedef { import("ipfsd-ctl/src/factory") } Factory */
 /**
- * @param {TestsInterface} common
+ * @param {Factory} common
  * @param {Object} options
  */
 module.exports = (common, options) => {
@@ -20,16 +20,12 @@ module.exports = (common, options) => {
 
     let ipfs
 
-    before(async function () {
-      // CI takes longer to instantiate the daemon, so we need to increase the
-      // timeout for the before step
-      this.timeout(60 * 1000)
-
-      ipfs = await common.setup()
+    before(async () => {
+      ipfs = (await common.spawn()).api
       await ipfs.add(fixtures.smallFile.data)
     })
 
-    after(() => common.teardown())
+    after(() => common.clean())
 
     it('should return a Readable Stream of Readable Streams', async () => {
       const stream = ipfs.getReadableStream(fixtures.smallFile.cid)

--- a/src/files-regular/get-readable-stream.js
+++ b/src/files-regular/get-readable-stream.js
@@ -6,10 +6,14 @@ const through = require('through2')
 const { getDescribe, getIt, expect } = require('../utils/mocha')
 const getStream = require('get-stream')
 
-module.exports = (createCommon, options) => {
+/** @typedef { import("ipfsd-ctl").TestsInterface } TestsInterface */
+/**
+ * @param {TestsInterface} common
+ * @param {Object} options
+ */
+module.exports = (common, options) => {
   const describe = getDescribe(options)
   const it = getIt(options)
-  const common = createCommon()
 
   describe('.getReadableStream', function () {
     this.timeout(40 * 1000)

--- a/src/files-regular/get.js
+++ b/src/files-regular/get.js
@@ -6,9 +6,9 @@ const bs58 = require('bs58')
 const CID = require('cids')
 const { getDescribe, getIt, expect } = require('../utils/mocha')
 
-/** @typedef { import("ipfsd-ctl").TestsInterface } TestsInterface */
+/** @typedef { import("ipfsd-ctl/src/factory") } Factory */
 /**
- * @param {TestsInterface} common
+ * @param {Factory} common
  * @param {Object} options
  */
 module.exports = (common, options) => {
@@ -20,17 +20,13 @@ module.exports = (common, options) => {
 
     let ipfs
 
-    before(async function () {
-      // CI takes longer to instantiate the daemon, so we need to increase the
-      // timeout for the before step
-      this.timeout(60 * 1000)
-
-      ipfs = await common.setup()
+    before(async () => {
+      ipfs = (await common.spawn()).api
       await ipfs.add(fixtures.smallFile.data)
       await ipfs.add(fixtures.bigFile.data)
     })
 
-    after(() => common.teardown())
+    after(() => common.clean())
 
     it('should get with a base58 encoded multihash', async () => {
       const files = await ipfs.get(fixtures.smallFile.cid)

--- a/src/files-regular/get.js
+++ b/src/files-regular/get.js
@@ -6,10 +6,14 @@ const bs58 = require('bs58')
 const CID = require('cids')
 const { getDescribe, getIt, expect } = require('../utils/mocha')
 
-module.exports = (createCommon, options) => {
+/** @typedef { import("ipfsd-ctl").TestsInterface } TestsInterface */
+/**
+ * @param {TestsInterface} common
+ * @param {Object} options
+ */
+module.exports = (common, options) => {
   const describe = getDescribe(options)
   const it = getIt(options)
-  const common = createCommon()
 
   describe('.get', function () {
     this.timeout(40 * 1000)

--- a/src/files-regular/ls-pull-stream.js
+++ b/src/files-regular/ls-pull-stream.js
@@ -5,10 +5,14 @@ const { fixtures } = require('./utils')
 const { getDescribe, getIt, expect } = require('../utils/mocha')
 const pullToPromise = require('pull-to-promise')
 
-module.exports = (createCommon, options) => {
+/** @typedef { import("ipfsd-ctl").TestsInterface } TestsInterface */
+/**
+ * @param {TestsInterface} common
+ * @param {Object} options
+ */
+module.exports = (common, options) => {
   const describe = getDescribe(options)
   const it = getIt(options)
-  const common = createCommon()
 
   describe('.lsPullStream', function () {
     this.timeout(40 * 1000)

--- a/src/files-regular/ls-pull-stream.js
+++ b/src/files-regular/ls-pull-stream.js
@@ -5,9 +5,9 @@ const { fixtures } = require('./utils')
 const { getDescribe, getIt, expect } = require('../utils/mocha')
 const pullToPromise = require('pull-to-promise')
 
-/** @typedef { import("ipfsd-ctl").TestsInterface } TestsInterface */
+/** @typedef { import("ipfsd-ctl/src/factory") } Factory */
 /**
- * @param {TestsInterface} common
+ * @param {Factory} common
  * @param {Object} options
  */
 module.exports = (common, options) => {
@@ -19,15 +19,11 @@ module.exports = (common, options) => {
 
     let ipfs
 
-    before(async function () {
-      // CI takes longer to instantiate the daemon, so we need to increase the
-      // timeout for the before step
-      this.timeout(60 * 1000)
-
-      ipfs = await common.setup()
+    before(async () => {
+      ipfs = (await common.spawn()).api
     })
 
-    after(() => common.teardown())
+    after(() => common.clean())
 
     it('should pull stream ls with a base58 encoded CID', async function () {
       const content = (name) => ({

--- a/src/files-regular/ls-readable-stream.js
+++ b/src/files-regular/ls-readable-stream.js
@@ -5,10 +5,14 @@ const { fixtures } = require('./utils')
 const { getDescribe, getIt, expect } = require('../utils/mocha')
 const getStream = require('get-stream')
 
-module.exports = (createCommon, options) => {
+/** @typedef { import("ipfsd-ctl").TestsInterface } TestsInterface */
+/**
+ * @param {TestsInterface} common
+ * @param {Object} options
+ */
+module.exports = (common, options) => {
   const describe = getDescribe(options)
   const it = getIt(options)
-  const common = createCommon()
 
   describe('.lsReadableStream', function () {
     this.timeout(40 * 1000)

--- a/src/files-regular/ls-readable-stream.js
+++ b/src/files-regular/ls-readable-stream.js
@@ -5,9 +5,9 @@ const { fixtures } = require('./utils')
 const { getDescribe, getIt, expect } = require('../utils/mocha')
 const getStream = require('get-stream')
 
-/** @typedef { import("ipfsd-ctl").TestsInterface } TestsInterface */
+/** @typedef { import("ipfsd-ctl/src/factory") } Factory */
 /**
- * @param {TestsInterface} common
+ * @param {Factory} common
  * @param {Object} options
  */
 module.exports = (common, options) => {
@@ -19,15 +19,11 @@ module.exports = (common, options) => {
 
     let ipfs
 
-    before(async function () {
-      // CI takes longer to instantiate the daemon, so we need to increase the
-      // timeout for the before step
-      this.timeout(60 * 1000)
-
-      ipfs = await common.setup()
+    before(async () => {
+      ipfs = (await common.spawn()).api
     })
 
-    after(() => common.teardown())
+    after(() => common.clean())
 
     it('should readable stream ls with a base58 encoded CID', async function () {
       const content = (name) => ({

--- a/src/files-regular/ls.js
+++ b/src/files-regular/ls.js
@@ -7,10 +7,14 @@ const CID = require('cids')
 
 const randomName = prefix => `${prefix}${Math.round(Math.random() * 1000)}`
 
-module.exports = (createCommon, options) => {
+/** @typedef { import("ipfsd-ctl").TestsInterface } TestsInterface */
+/**
+ * @param {TestsInterface} common
+ * @param {Object} options
+ */
+module.exports = (common, options) => {
   const describe = getDescribe(options)
   const it = getIt(options)
-  const common = createCommon()
 
   describe('.ls', function () {
     this.timeout(40 * 1000)

--- a/src/files-regular/ls.js
+++ b/src/files-regular/ls.js
@@ -7,9 +7,9 @@ const CID = require('cids')
 
 const randomName = prefix => `${prefix}${Math.round(Math.random() * 1000)}`
 
-/** @typedef { import("ipfsd-ctl").TestsInterface } TestsInterface */
+/** @typedef { import("ipfsd-ctl/src/factory") } Factory */
 /**
- * @param {TestsInterface} common
+ * @param {Factory} common
  * @param {Object} options
  */
 module.exports = (common, options) => {
@@ -21,15 +21,11 @@ module.exports = (common, options) => {
 
     let ipfs
 
-    before(async function () {
-      // CI takes longer to instantiate the daemon, so we need to increase the
-      // timeout for the before step
-      this.timeout(60 * 1000)
-
-      ipfs = await common.setup()
+    before(async () => {
+      ipfs = (await common.spawn()).api
     })
 
-    after(() => common.teardown())
+    after(() => common.clean())
 
     it('should ls with a base58 encoded CID', async function () {
       const content = (name) => ({

--- a/src/files-regular/refs-local-tests.js
+++ b/src/files-regular/refs-local-tests.js
@@ -4,9 +4,9 @@
 const { fixtures } = require('./utils')
 const { getDescribe, getIt, expect } = require('../utils/mocha')
 
-/** @typedef { import("ipfsd-ctl").TestsInterface } TestsInterface */
+/** @typedef { import("ipfsd-ctl/src/factory") } Factory */
 /**
- * @param {TestsInterface} common
+ * @param {Factory} common
  * @param {*} suiteName
  * @param {*} ipfsRefsLocal
  * @param {Object} options
@@ -20,15 +20,11 @@ module.exports = (common, suiteName, ipfsRefsLocal, options) => {
 
     let ipfs
 
-    before(async function () {
-      // CI takes longer to instantiate the daemon, so we need to increase the
-      // timeout for the before step
-      this.timeout(60 * 1000)
-
-      ipfs = await common.setup()
+    before(async () => {
+      ipfs = (await common.spawn()).api
     })
 
-    after(() => common.teardown())
+    after(() => common.clean())
 
     it('should get local refs', async function () {
       const content = (name) => ({

--- a/src/files-regular/refs-local-tests.js
+++ b/src/files-regular/refs-local-tests.js
@@ -4,10 +4,16 @@
 const { fixtures } = require('./utils')
 const { getDescribe, getIt, expect } = require('../utils/mocha')
 
-module.exports = (createCommon, suiteName, ipfsRefsLocal, options) => {
+/** @typedef { import("ipfsd-ctl").TestsInterface } TestsInterface */
+/**
+ * @param {TestsInterface} common
+ * @param {*} suiteName
+ * @param {*} ipfsRefsLocal
+ * @param {Object} options
+ */
+module.exports = (common, suiteName, ipfsRefsLocal, options) => {
   const describe = getDescribe(options)
   const it = getIt(options)
-  const common = createCommon()
 
   describe(suiteName, function () {
     this.timeout(40 * 1000)

--- a/src/files-regular/refs-tests.js
+++ b/src/files-regular/refs-tests.js
@@ -7,10 +7,16 @@ const { getDescribe, getIt, expect } = require('../utils/mocha')
 const loadFixture = require('aegir/fixtures')
 const CID = require('cids')
 
-module.exports = (createCommon, suiteName, ipfsRefs, options) => {
+/** @typedef { import("ipfsd-ctl").TestsInterface } TestsInterface */
+/**
+ * @param {TestsInterface} common
+ * @param {*} suiteName
+ * @param {*} ipfsRefs
+ * @param {Object} options
+ */
+module.exports = (common, suiteName, ipfsRefs, options) => {
   const describe = getDescribe(options)
   const it = getIt(options)
-  const common = createCommon()
 
   describe(suiteName, function () {
     this.timeout(40 * 1000)

--- a/src/files-regular/refs-tests.js
+++ b/src/files-regular/refs-tests.js
@@ -7,9 +7,9 @@ const { getDescribe, getIt, expect } = require('../utils/mocha')
 const loadFixture = require('aegir/fixtures')
 const CID = require('cids')
 
-/** @typedef { import("ipfsd-ctl").TestsInterface } TestsInterface */
+/** @typedef { import("ipfsd-ctl/src/factory") } Factory */
 /**
- * @param {TestsInterface} common
+ * @param {Factory} common
  * @param {*} suiteName
  * @param {*} ipfsRefs
  * @param {Object} options
@@ -23,12 +23,8 @@ module.exports = (common, suiteName, ipfsRefs, options) => {
 
     let ipfs, pbRootCb, dagRootCid
 
-    before(async function () {
-      // CI takes longer to instantiate the daemon, so we need to increase the
-      // timeout for the before step
-      this.timeout(60 * 1000)
-
-      ipfs = await common.setup()
+    before(async () => {
+      ipfs = (await common.spawn()).api
     })
 
     before(async function () {
@@ -41,7 +37,7 @@ module.exports = (common, suiteName, ipfsRefs, options) => {
       dagRootCid = cid
     })
 
-    after(() => common.teardown())
+    after(() => common.clean())
 
     for (const [name, options] of Object.entries(getRefsTests())) {
       const { path, params, expected, expectError, expectTimeout } = options

--- a/src/key/export.js
+++ b/src/key/export.js
@@ -4,10 +4,14 @@
 const hat = require('hat')
 const { getDescribe, getIt, expect } = require('../utils/mocha')
 
-module.exports = (createCommon, options) => {
+/** @typedef { import("ipfsd-ctl").TestsInterface } TestsInterface */
+/**
+ * @param {TestsInterface} common
+ * @param {Object} options
+ */
+module.exports = (common, options) => {
   const describe = getDescribe(options)
   const it = getIt(options)
-  const common = createCommon()
 
   describe('.key.export', () => {
     let ipfs

--- a/src/key/export.js
+++ b/src/key/export.js
@@ -4,9 +4,9 @@
 const hat = require('hat')
 const { getDescribe, getIt, expect } = require('../utils/mocha')
 
-/** @typedef { import("ipfsd-ctl").TestsInterface } TestsInterface */
+/** @typedef { import("ipfsd-ctl/src/factory") } Factory */
 /**
- * @param {TestsInterface} common
+ * @param {Factory} common
  * @param {Object} options
  */
 module.exports = (common, options) => {
@@ -16,15 +16,11 @@ module.exports = (common, options) => {
   describe('.key.export', () => {
     let ipfs
 
-    before(async function () {
-      // CI takes longer to instantiate the daemon, so we need to increase the
-      // timeout for the before step
-      this.timeout(60 * 1000)
-
-      ipfs = await common.setup()
+    before(async () => {
+      ipfs = (await common.spawn()).api
     })
 
-    after(() => common.teardown())
+    after(() => common.clean())
 
     it('should export "self" key', async function () {
       const pem = await ipfs.key.export('self', hat())

--- a/src/key/gen.js
+++ b/src/key/gen.js
@@ -4,9 +4,9 @@
 const hat = require('hat')
 const { getDescribe, getIt, expect } = require('../utils/mocha')
 
-/** @typedef { import("ipfsd-ctl").TestsInterface } TestsInterface */
+/** @typedef { import("ipfsd-ctl/src/factory") } Factory */
 /**
- * @param {TestsInterface} common
+ * @param {Factory} common
  * @param {Object} options
  */
 module.exports = (common, options) => {
@@ -20,15 +20,11 @@ module.exports = (common, options) => {
 
     let ipfs
 
-    before(async function () {
-      // CI takes longer to instantiate the daemon, so we need to increase the
-      // timeout for the before step
-      this.timeout(60 * 1000)
-
-      ipfs = await common.setup()
+    before(async () => {
+      ipfs = (await common.spawn()).api
     })
 
-    after(() => common.teardown())
+    after(() => common.clean())
 
     keyTypes.forEach((kt) => {
       it(`should generate a new ${kt.type} key`, async function () {

--- a/src/key/gen.js
+++ b/src/key/gen.js
@@ -4,10 +4,14 @@
 const hat = require('hat')
 const { getDescribe, getIt, expect } = require('../utils/mocha')
 
-module.exports = (createCommon, options) => {
+/** @typedef { import("ipfsd-ctl").TestsInterface } TestsInterface */
+/**
+ * @param {TestsInterface} common
+ * @param {Object} options
+ */
+module.exports = (common, options) => {
   const describe = getDescribe(options)
   const it = getIt(options)
-  const common = createCommon()
 
   describe('.key.gen', () => {
     const keyTypes = [

--- a/src/key/import.js
+++ b/src/key/import.js
@@ -4,9 +4,9 @@
 const hat = require('hat')
 const { getDescribe, getIt, expect } = require('../utils/mocha')
 
-/** @typedef { import("ipfsd-ctl").TestsInterface } TestsInterface */
+/** @typedef { import("ipfsd-ctl/src/factory") } Factory */
 /**
- * @param {TestsInterface} common
+ * @param {Factory} common
  * @param {Object} options
  */
 module.exports = (common, options) => {
@@ -16,15 +16,11 @@ module.exports = (common, options) => {
   describe('.key.import', () => {
     let ipfs
 
-    before(async function () {
-      // CI takes longer to instantiate the daemon, so we need to increase the
-      // timeout for the before step
-      this.timeout(60 * 1000)
-
-      ipfs = await common.setup()
+    before(async () => {
+      ipfs = (await common.spawn()).api
     })
 
-    after(() => common.teardown())
+    after(() => common.clean())
 
     it('should import an exported key', async () => {
       const password = hat()

--- a/src/key/import.js
+++ b/src/key/import.js
@@ -4,10 +4,14 @@
 const hat = require('hat')
 const { getDescribe, getIt, expect } = require('../utils/mocha')
 
-module.exports = (createCommon, options) => {
+/** @typedef { import("ipfsd-ctl").TestsInterface } TestsInterface */
+/**
+ * @param {TestsInterface} common
+ * @param {Object} options
+ */
+module.exports = (common, options) => {
   const describe = getDescribe(options)
   const it = getIt(options)
-  const common = createCommon()
 
   describe('.key.import', () => {
     let ipfs

--- a/src/key/list.js
+++ b/src/key/list.js
@@ -5,10 +5,14 @@ const pTimes = require('p-times')
 const hat = require('hat')
 const { getDescribe, getIt, expect } = require('../utils/mocha')
 
-module.exports = (createCommon, options) => {
+/** @typedef { import("ipfsd-ctl").TestsInterface } TestsInterface */
+/**
+ * @param {TestsInterface} common
+ * @param {Object} options
+ */
+module.exports = (common, options) => {
   const describe = getDescribe(options)
   const it = getIt(options)
-  const common = createCommon()
 
   describe('.key.list', () => {
     let ipfs

--- a/src/key/list.js
+++ b/src/key/list.js
@@ -5,9 +5,9 @@ const pTimes = require('p-times')
 const hat = require('hat')
 const { getDescribe, getIt, expect } = require('../utils/mocha')
 
-/** @typedef { import("ipfsd-ctl").TestsInterface } TestsInterface */
+/** @typedef { import("ipfsd-ctl/src/factory") } Factory */
 /**
- * @param {TestsInterface} common
+ * @param {Factory} common
  * @param {Object} options
  */
 module.exports = (common, options) => {
@@ -17,15 +17,11 @@ module.exports = (common, options) => {
   describe('.key.list', () => {
     let ipfs
 
-    before(async function () {
-      // CI takes longer to instantiate the daemon, so we need to increase the
-      // timeout for the before step
-      this.timeout(60 * 1000)
-
-      ipfs = await common.setup()
+    before(async () => {
+      ipfs = (await common.spawn()).api
     })
 
-    after(() => common.teardown())
+    after(() => common.clean())
 
     it('should list all the keys', async function () {
       this.timeout(60 * 1000)

--- a/src/key/rename.js
+++ b/src/key/rename.js
@@ -4,9 +4,9 @@
 const hat = require('hat')
 const { getDescribe, getIt, expect } = require('../utils/mocha')
 
-/** @typedef { import("ipfsd-ctl").TestsInterface } TestsInterface */
+/** @typedef { import("ipfsd-ctl/src/factory") } Factory */
 /**
- * @param {TestsInterface} common
+ * @param {Factory} common
  * @param {Object} options
  */
 module.exports = (common, options) => {
@@ -16,15 +16,11 @@ module.exports = (common, options) => {
   describe('.key.rename', () => {
     let ipfs
 
-    before(async function () {
-      // CI takes longer to instantiate the daemon, so we need to increase the
-      // timeout for the before step
-      this.timeout(60 * 1000)
-
-      ipfs = await common.setup()
+    before(async () => {
+      ipfs = (await common.spawn()).api
     })
 
-    after(() => common.teardown())
+    after(() => common.clean())
 
     it('should rename a key', async function () {
       this.timeout(30 * 1000)

--- a/src/key/rename.js
+++ b/src/key/rename.js
@@ -4,10 +4,14 @@
 const hat = require('hat')
 const { getDescribe, getIt, expect } = require('../utils/mocha')
 
-module.exports = (createCommon, options) => {
+/** @typedef { import("ipfsd-ctl").TestsInterface } TestsInterface */
+/**
+ * @param {TestsInterface} common
+ * @param {Object} options
+ */
+module.exports = (common, options) => {
   const describe = getDescribe(options)
   const it = getIt(options)
-  const common = createCommon()
 
   describe('.key.rename', () => {
     let ipfs

--- a/src/key/rm.js
+++ b/src/key/rm.js
@@ -4,10 +4,14 @@
 const hat = require('hat')
 const { getDescribe, getIt, expect } = require('../utils/mocha')
 
-module.exports = (createCommon, options) => {
+/** @typedef { import("ipfsd-ctl").TestsInterface } TestsInterface */
+/**
+ * @param {TestsInterface} common
+ * @param {Object} options
+ */
+module.exports = (common, options) => {
   const describe = getDescribe(options)
   const it = getIt(options)
-  const common = createCommon()
 
   describe('.key.rm', () => {
     let ipfs

--- a/src/key/rm.js
+++ b/src/key/rm.js
@@ -4,9 +4,9 @@
 const hat = require('hat')
 const { getDescribe, getIt, expect } = require('../utils/mocha')
 
-/** @typedef { import("ipfsd-ctl").TestsInterface } TestsInterface */
+/** @typedef { import("ipfsd-ctl/src/factory") } Factory */
 /**
- * @param {TestsInterface} common
+ * @param {Factory} common
  * @param {Object} options
  */
 module.exports = (common, options) => {
@@ -16,15 +16,11 @@ module.exports = (common, options) => {
   describe('.key.rm', () => {
     let ipfs
 
-    before(async function () {
-      // CI takes longer to instantiate the daemon, so we need to increase the
-      // timeout for the before step
-      this.timeout(60 * 1000)
-
-      ipfs = await common.setup()
+    before(async () => {
+      ipfs = (await common.spawn()).api
     })
 
-    after(() => common.teardown())
+    after(() => common.clean())
 
     it('should rm a key', async function () {
       this.timeout(30 * 1000)

--- a/src/miscellaneous/dns.js
+++ b/src/miscellaneous/dns.js
@@ -13,7 +13,7 @@ module.exports = (common, options) => {
   const it = getIt(options)
 
   describe('.dns', function () {
-    this.timeout(10 * 1000)
+    this.timeout(60 * 1000)
     this.retries(3)
     let ipfs
 

--- a/src/miscellaneous/dns.js
+++ b/src/miscellaneous/dns.js
@@ -3,10 +3,14 @@
 
 const { getDescribe, getIt, expect } = require('../utils/mocha')
 
-module.exports = (createCommon, options) => {
+/** @typedef { import("ipfsd-ctl").TestsInterface } TestsInterface */
+/**
+ * @param {TestsInterface} common
+ * @param {Object} options
+ */
+module.exports = (common, options) => {
   const describe = getDescribe(options)
   const it = getIt(options)
-  const common = createCommon()
 
   describe('.dns', function () {
     this.timeout(10 * 1000)

--- a/src/miscellaneous/dns.js
+++ b/src/miscellaneous/dns.js
@@ -3,9 +3,9 @@
 
 const { getDescribe, getIt, expect } = require('../utils/mocha')
 
-/** @typedef { import("ipfsd-ctl").TestsInterface } TestsInterface */
+/** @typedef { import("ipfsd-ctl/src/factory") } Factory */
 /**
- * @param {TestsInterface} common
+ * @param {Factory} common
  * @param {Object} options
  */
 module.exports = (common, options) => {
@@ -17,15 +17,11 @@ module.exports = (common, options) => {
     this.retries(3)
     let ipfs
 
-    before(async function () {
-      // CI takes longer to instantiate the daemon, so we need to increase the
-      // timeout for the before step
-      this.timeout(60 * 1000)
-
-      ipfs = await common.setup()
+    before(async () => {
+      ipfs = (await common.spawn()).api
     })
 
-    after(() => common.teardown())
+    after(() => common.clean())
 
     it('should non-recursively resolve ipfs.io', async () => {
       const res = await ipfs.dns('ipfs.io', { recursive: false })

--- a/src/miscellaneous/id.js
+++ b/src/miscellaneous/id.js
@@ -3,10 +3,14 @@
 
 const { getDescribe, getIt, expect } = require('../utils/mocha')
 
-module.exports = (createCommon, options) => {
+/** @typedef { import("ipfsd-ctl").TestsInterface } TestsInterface */
+/**
+ * @param {TestsInterface} common
+ * @param {Object} options
+ */
+module.exports = (common, options) => {
   const describe = getDescribe(options)
   const it = getIt(options)
-  const common = createCommon()
 
   describe('.id', function () {
     this.timeout(60 * 1000)

--- a/src/miscellaneous/id.js
+++ b/src/miscellaneous/id.js
@@ -3,9 +3,9 @@
 
 const { getDescribe, getIt, expect } = require('../utils/mocha')
 
-/** @typedef { import("ipfsd-ctl").TestsInterface } TestsInterface */
+/** @typedef { import("ipfsd-ctl/src/factory") } Factory */
 /**
- * @param {TestsInterface} common
+ * @param {Factory} common
  * @param {Object} options
  */
 module.exports = (common, options) => {
@@ -17,10 +17,10 @@ module.exports = (common, options) => {
     let ipfs
 
     before(async () => {
-      ipfs = await common.setup()
+      ipfs = (await common.spawn()).api
     })
 
-    after(() => common.teardown())
+    after(() => common.clean())
 
     it('should get the node ID', async () => {
       const res = await ipfs.id()

--- a/src/miscellaneous/resolve.js
+++ b/src/miscellaneous/resolve.js
@@ -81,9 +81,8 @@ module.exports = (common, options) => {
 
     it('should resolve IPNS link recursively', async function () {
       this.timeout(20 * 1000)
-      const node = await common.setup({ type: 'js' })
+      const node = await common.setup({ type: 'go' })
       await ipfs.swarm.connect(node.peerId.addresses[0])
-
       const [{ path }] = await ipfs.add(Buffer.from('should resolve a record recursive === true'))
       const { id: keyId } = await ipfs.key.gen('key-name', { type: 'rsa', size: 2048 })
 

--- a/src/miscellaneous/resolve.js
+++ b/src/miscellaneous/resolve.js
@@ -7,9 +7,9 @@ const hat = require('hat')
 const multibase = require('multibase')
 const { getDescribe, getIt, expect } = require('../utils/mocha')
 
-/** @typedef { import("ipfsd-ctl").TestsInterface } TestsInterface */
+/** @typedef { import("ipfsd-ctl/src/factory") } Factory */
 /**
- * @param {TestsInterface} common
+ * @param {Factory} common
  * @param {Object} options
  */
 module.exports = (common, options) => {
@@ -21,10 +21,10 @@ module.exports = (common, options) => {
     let ipfs
 
     before(async () => {
-      ipfs = await common.setup()
+      ipfs = (await common.spawn()).api
     })
 
-    after(() => common.teardown())
+    after(() => common.clean())
 
     it('should resolve an IPFS hash', async () => {
       const content = loadFixture('test/fixtures/testfile.txt', 'interface-ipfs-core')
@@ -81,7 +81,7 @@ module.exports = (common, options) => {
 
     it('should resolve IPNS link recursively', async function () {
       this.timeout(20 * 1000)
-      const node = await common.setup({ type: 'go' })
+      const node = (await common.spawn({ type: 'go' })).api
       await ipfs.swarm.connect(node.peerId.addresses[0])
       const [{ path }] = await ipfs.add(Buffer.from('should resolve a record recursive === true'))
       const { id: keyId } = await ipfs.key.gen('key-name', { type: 'rsa', size: 2048 })

--- a/src/miscellaneous/resolve.js
+++ b/src/miscellaneous/resolve.js
@@ -7,10 +7,14 @@ const hat = require('hat')
 const multibase = require('multibase')
 const { getDescribe, getIt, expect } = require('../utils/mocha')
 
-module.exports = (createCommon, options) => {
+/** @typedef { import("ipfsd-ctl").TestsInterface } TestsInterface */
+/**
+ * @param {TestsInterface} common
+ * @param {Object} options
+ */
+module.exports = (common, options) => {
   const describe = getDescribe(options)
   const it = getIt(options)
-  const common = createCommon()
 
   describe('.resolve', function () {
     this.timeout(60 * 1000)

--- a/src/miscellaneous/resolve.js
+++ b/src/miscellaneous/resolve.js
@@ -81,15 +81,8 @@ module.exports = (common, options) => {
 
     it('should resolve IPNS link recursively', async function () {
       this.timeout(20 * 1000)
-
-      // Ensure another node exists for publishing to  - only required by go-ipfs
-      if (ipfs.peerId.agentVersion.includes('go-ipfs')) {
-        const node = await common.setup()
-
-        // this fails in the browser because there is no relay node available to connect the two
-        // nodes, but we only need this for go-ipfs as it doesn't support the `allowOffline` flag yet
-        await ipfs.swarm.connect(node.peerId.addresses.find((a) => a.includes('127.0.0.1')))
-      }
+      const node = await common.setup({ type: 'js' })
+      await ipfs.swarm.connect(node.peerId.addresses[0])
 
       const [{ path }] = await ipfs.add(Buffer.from('should resolve a record recursive === true'))
       const { id: keyId } = await ipfs.key.gen('key-name', { type: 'rsa', size: 2048 })

--- a/src/miscellaneous/stop.js
+++ b/src/miscellaneous/stop.js
@@ -3,9 +3,9 @@
 
 const { getDescribe, getIt, expect } = require('../utils/mocha')
 
-/** @typedef { import("ipfsd-ctl").TestsInterface } TestsInterface */
+/** @typedef { import("ipfsd-ctl/src/factory") } Factory */
 /**
- * @param {TestsInterface} common
+ * @param {Factory} common
  * @param {Object} options
  */
 module.exports = (common, options) => {
@@ -16,7 +16,7 @@ module.exports = (common, options) => {
     this.timeout(60 * 1000)
 
     it('should stop the node', async () => {
-      const ipfs = await common.node()
+      const ipfs = await common.spawn()
 
       await ipfs.stop()
       // Trying to stop an already stopped node should return an error

--- a/src/miscellaneous/stop.js
+++ b/src/miscellaneous/stop.js
@@ -3,15 +3,20 @@
 
 const { getDescribe, getIt, expect } = require('../utils/mocha')
 
-module.exports = (createCommon, options) => {
+/** @typedef { import("ipfsd-ctl").TestsInterface } TestsInterface */
+/**
+ * @param {TestsInterface} common
+ * @param {Object} options
+ */
+module.exports = (common, options) => {
   const describe = getDescribe(options)
   const it = getIt(options)
-  const common = createCommon()
 
-  describe('.stop', () => {
-    it('should stop the node', async function () {
-      this.timeout(10 * 1000)
-      const ipfs = await common.setup()
+  describe('.stop', function () {
+    this.timeout(60 * 1000)
+
+    it('should stop the node', async () => {
+      const ipfs = await common.node()
 
       await ipfs.stop()
 

--- a/src/miscellaneous/stop.js
+++ b/src/miscellaneous/stop.js
@@ -19,10 +19,9 @@ module.exports = (common, options) => {
       const ipfs = await common.node()
 
       await ipfs.stop()
-
       // Trying to stop an already stopped node should return an error
       // as the node can't respond to requests anymore
-      return expect(ipfs.stop()).to.eventually.be.rejected()
+      return expect(ipfs.api.stop()).to.eventually.be.rejected()
     })
   })
 }

--- a/src/miscellaneous/version.js
+++ b/src/miscellaneous/version.js
@@ -3,10 +3,14 @@
 
 const { getDescribe, getIt, expect } = require('../utils/mocha')
 
-module.exports = (createCommon, options) => {
+/** @typedef { import("ipfsd-ctl").TestsInterface } TestsInterface */
+/**
+ * @param {TestsInterface} common
+ * @param {Object} options
+ */
+module.exports = (common, options) => {
   const describe = getDescribe(options)
   const it = getIt(options)
-  const common = createCommon()
 
   describe('.version', () => {
     let ipfs

--- a/src/miscellaneous/version.js
+++ b/src/miscellaneous/version.js
@@ -3,9 +3,9 @@
 
 const { getDescribe, getIt, expect } = require('../utils/mocha')
 
-/** @typedef { import("ipfsd-ctl").TestsInterface } TestsInterface */
+/** @typedef { import("ipfsd-ctl/src/factory") } Factory */
 /**
- * @param {TestsInterface} common
+ * @param {Factory} common
  * @param {Object} options
  */
 module.exports = (common, options) => {
@@ -15,15 +15,11 @@ module.exports = (common, options) => {
   describe('.version', () => {
     let ipfs
 
-    before(async function () {
-      // CI takes longer to instantiate the daemon, so we need to increase the
-      // timeout for the before step
-      this.timeout(60 * 1000)
-
-      ipfs = await common.setup()
+    before(async () => {
+      ipfs = (await common.spawn()).api
     })
 
-    after(() => common.teardown())
+    after(() => common.clean())
 
     it('should get the node version', async () => {
       const result = await ipfs.version()

--- a/src/name-pubsub/cancel.js
+++ b/src/name-pubsub/cancel.js
@@ -6,9 +6,9 @@ const { promisify } = require('es6-promisify')
 
 const { getDescribe, getIt, expect } = require('../utils/mocha')
 
-/** @typedef { import("ipfsd-ctl").TestsInterface } TestsInterface */
+/** @typedef { import("ipfsd-ctl/src/factory") } Factory */
 /**
- * @param {TestsInterface} common
+ * @param {Factory} common
  * @param {Object} options
  */
 module.exports = (common, options) => {
@@ -19,16 +19,12 @@ module.exports = (common, options) => {
     let ipfs
     let nodeId
 
-    before(async function () {
-      // CI takes longer to instantiate the daemon, so we need to increase the
-      // timeout for the before step
-      this.timeout(60 * 1000)
-
-      ipfs = await common.setup()
+    before(async () => {
+      ipfs = (await common.spawn()).api
       nodeId = ipfs.peerId.id
     })
 
-    after(() => common.teardown())
+    after(() => common.clean())
 
     it('should return false when the name that is intended to cancel is not subscribed', async function () {
       this.timeout(60 * 1000)

--- a/src/name-pubsub/cancel.js
+++ b/src/name-pubsub/cancel.js
@@ -6,10 +6,14 @@ const { promisify } = require('es6-promisify')
 
 const { getDescribe, getIt, expect } = require('../utils/mocha')
 
-module.exports = (createCommon, options) => {
+/** @typedef { import("ipfsd-ctl").TestsInterface } TestsInterface */
+/**
+ * @param {TestsInterface} common
+ * @param {Object} options
+ */
+module.exports = (common, options) => {
   const describe = getDescribe(options)
   const it = getIt(options)
-  const common = createCommon()
 
   describe('.name.pubsub.cancel', () => {
     let ipfs

--- a/src/name-pubsub/state.js
+++ b/src/name-pubsub/state.js
@@ -3,9 +3,9 @@
 
 const { getDescribe, getIt, expect } = require('../utils/mocha')
 
-/** @typedef { import("ipfsd-ctl").TestsInterface } TestsInterface */
+/** @typedef { import("ipfsd-ctl/src/factory") } Factory */
 /**
- * @param {TestsInterface} common
+ * @param {Factory} common
  * @param {Object} options
  */
 module.exports = (common, options) => {
@@ -15,15 +15,11 @@ module.exports = (common, options) => {
   describe('.name.pubsub.state', () => {
     let ipfs
 
-    before(async function () {
-      // CI takes longer to instantiate the daemon, so we need to increase the
-      // timeout for the before step
-      this.timeout(60 * 1000)
-
-      ipfs = await common.setup()
+    before(async () => {
+      ipfs = (await common.spawn()).api
     })
 
-    after(() => common.teardown())
+    after(() => common.clean())
 
     it('should get the current state of pubsub', async function () {
       this.timeout(50 * 1000)

--- a/src/name-pubsub/state.js
+++ b/src/name-pubsub/state.js
@@ -3,10 +3,14 @@
 
 const { getDescribe, getIt, expect } = require('../utils/mocha')
 
-module.exports = (createCommon, options) => {
+/** @typedef { import("ipfsd-ctl").TestsInterface } TestsInterface */
+/**
+ * @param {TestsInterface} common
+ * @param {Object} options
+ */
+module.exports = (common, options) => {
   const describe = getDescribe(options)
   const it = getIt(options)
-  const common = createCommon()
 
   describe('.name.pubsub.state', () => {
     let ipfs

--- a/src/name-pubsub/subs.js
+++ b/src/name-pubsub/subs.js
@@ -3,10 +3,14 @@
 
 const { getDescribe, getIt, expect } = require('../utils/mocha')
 
-module.exports = (createCommon, options) => {
+/** @typedef { import("ipfsd-ctl").TestsInterface } TestsInterface */
+/**
+ * @param {TestsInterface} common
+ * @param {Object} options
+ */
+module.exports = (common, options) => {
   const describe = getDescribe(options)
   const it = getIt(options)
-  const common = createCommon()
 
   describe('.name.pubsub.subs', () => {
     let ipfs

--- a/src/name-pubsub/subs.js
+++ b/src/name-pubsub/subs.js
@@ -3,9 +3,9 @@
 
 const { getDescribe, getIt, expect } = require('../utils/mocha')
 
-/** @typedef { import("ipfsd-ctl").TestsInterface } TestsInterface */
+/** @typedef { import("ipfsd-ctl/src/factory") } Factory */
 /**
- * @param {TestsInterface} common
+ * @param {Factory} common
  * @param {Object} options
  */
 module.exports = (common, options) => {
@@ -15,15 +15,11 @@ module.exports = (common, options) => {
   describe('.name.pubsub.subs', () => {
     let ipfs
 
-    before(async function () {
-      // CI takes longer to instantiate the daemon, so we need to increase the
-      // timeout for the before step
-      this.timeout(60 * 1000)
-
-      ipfs = await common.setup()
+    before(async () => {
+      ipfs = (await common.spawn()).api
     })
 
-    after(() => common.teardown())
+    after(() => common.clean())
 
     it('should get an empty array as a result of subscriptions before any resolve', async function () {
       this.timeout(60 * 1000)

--- a/src/name/publish.js
+++ b/src/name/publish.js
@@ -6,9 +6,9 @@ const hat = require('hat')
 const { fixture } = require('./utils')
 const { getDescribe, getIt, expect } = require('../utils/mocha')
 
-/** @typedef { import("ipfsd-ctl").TestsInterface } TestsInterface */
+/** @typedef { import("ipfsd-ctl/src/factory") } Factory */
 /**
- * @param {TestsInterface} common
+ * @param {Factory} common
  * @param {Object} options
  */
 module.exports = (common, options) => {
@@ -20,17 +20,13 @@ module.exports = (common, options) => {
     let ipfs
     let nodeId
 
-    before(async function () {
-      // CI takes longer to instantiate the daemon, so we need to increase the
-      // timeout for the before step
-      this.timeout(60 * 1000)
-
-      ipfs = await common.setup()
+    before(async () => {
+      ipfs = (await common.spawn()).api
       nodeId = ipfs.peerId.id
       await ipfs.add(fixture.data, { pin: false })
     })
 
-    after(() => common.teardown())
+    after(() => common.clean())
 
     it('should publish an IPNS record with the default params', async function () {
       this.timeout(50 * 1000)

--- a/src/name/publish.js
+++ b/src/name/publish.js
@@ -6,10 +6,14 @@ const hat = require('hat')
 const { fixture } = require('./utils')
 const { getDescribe, getIt, expect } = require('../utils/mocha')
 
-module.exports = (createCommon, options) => {
+/** @typedef { import("ipfsd-ctl").TestsInterface } TestsInterface */
+/**
+ * @param {TestsInterface} common
+ * @param {Object} options
+ */
+module.exports = (common, options) => {
   const describe = getDescribe(options)
   const it = getIt(options)
-  const common = createCommon()
 
   describe('.name.publish offline', () => {
     const keyName = hat()

--- a/src/name/resolve.js
+++ b/src/name/resolve.js
@@ -5,9 +5,9 @@ const { getDescribe, getIt, expect } = require('../utils/mocha')
 const delay = require('delay')
 const CID = require('cids')
 
-/** @typedef { import("ipfsd-ctl").TestsInterface } TestsInterface */
+/** @typedef { import("ipfsd-ctl/src/factory") } Factory */
 /**
- * @param {TestsInterface} common
+ * @param {Factory} common
  * @param {Object} options
  */
 module.exports = (common, options) => {
@@ -19,11 +19,11 @@ module.exports = (common, options) => {
     let nodeId
 
     before(async () => {
-      ipfs = await common.setup()
+      ipfs = (await common.spawn()).api
       nodeId = ipfs.peerId.id
     })
 
-    after(() => common.teardown())
+    after(() => common.clean())
 
     it('should resolve a record default options', async function () {
       this.timeout(20 * 1000)
@@ -135,10 +135,10 @@ module.exports = (common, options) => {
     this.retries(5)
 
     before(async () => {
-      ipfs = await common.setup()
+      ipfs = (await common.spawn()).api
     })
 
-    after(() => common.teardown())
+    after(() => common.clean())
 
     it('should resolve /ipns/ipfs.io', async () => {
       return expect(await ipfs.name.resolve('/ipns/ipfs.io'))

--- a/src/name/resolve.js
+++ b/src/name/resolve.js
@@ -5,12 +5,16 @@ const { getDescribe, getIt, expect } = require('../utils/mocha')
 const delay = require('delay')
 const CID = require('cids')
 
-module.exports = (createCommon, options) => {
+/** @typedef { import("ipfsd-ctl").TestsInterface } TestsInterface */
+/**
+ * @param {TestsInterface} common
+ * @param {Object} options
+ */
+module.exports = (common, options) => {
   const describe = getDescribe(options)
   const it = getIt(options)
 
-  describe('.name.resolve offline', () => {
-    const common = createCommon()
+  describe('.name.resolve offline', function () {
     let ipfs
     let nodeId
 
@@ -127,7 +131,6 @@ module.exports = (createCommon, options) => {
   })
 
   describe('.name.resolve dns', function () {
-    const common = createCommon()
     let ipfs
     this.retries(5)
 

--- a/src/object/data.js
+++ b/src/object/data.js
@@ -5,10 +5,14 @@ const bs58 = require('bs58')
 const hat = require('hat')
 const { getDescribe, getIt, expect } = require('../utils/mocha')
 
-module.exports = (createCommon, options) => {
+/** @typedef { import("ipfsd-ctl").TestsInterface } TestsInterface */
+/**
+ * @param {TestsInterface} common
+ * @param {Object} options
+ */
+module.exports = (common, options) => {
   const describe = getDescribe(options)
   const it = getIt(options)
-  const common = createCommon()
 
   describe('.object.data', function () {
     this.timeout(80 * 1000)

--- a/src/object/data.js
+++ b/src/object/data.js
@@ -5,9 +5,9 @@ const bs58 = require('bs58')
 const hat = require('hat')
 const { getDescribe, getIt, expect } = require('../utils/mocha')
 
-/** @typedef { import("ipfsd-ctl").TestsInterface } TestsInterface */
+/** @typedef { import("ipfsd-ctl/src/factory") } Factory */
 /**
- * @param {TestsInterface} common
+ * @param {Factory} common
  * @param {Object} options
  */
 module.exports = (common, options) => {
@@ -19,15 +19,11 @@ module.exports = (common, options) => {
 
     let ipfs
 
-    before(async function () {
-      // CI takes longer to instantiate the daemon, so we need to increase the
-      // timeout for the before step
-      this.timeout(60 * 1000)
-
-      ipfs = await common.setup()
+    before(async () => {
+      ipfs = (await common.spawn()).api
     })
 
-    after(() => common.teardown())
+    after(() => common.clean())
 
     it('should get data by multihash', async () => {
       const testObj = {

--- a/src/object/get.js
+++ b/src/object/get.js
@@ -9,10 +9,14 @@ const UnixFs = require('ipfs-unixfs')
 const crypto = require('crypto')
 const { asDAGLink } = require('./utils')
 
-module.exports = (createCommon, options) => {
+/** @typedef { import("ipfsd-ctl").TestsInterface } TestsInterface */
+/**
+ * @param {TestsInterface} common
+ * @param {Object} options
+ */
+module.exports = (common, options) => {
   const describe = getDescribe(options)
   const it = getIt(options)
-  const common = createCommon()
 
   describe('.object.get', function () {
     this.timeout(80 * 1000)

--- a/src/object/get.js
+++ b/src/object/get.js
@@ -9,9 +9,9 @@ const UnixFs = require('ipfs-unixfs')
 const crypto = require('crypto')
 const { asDAGLink } = require('./utils')
 
-/** @typedef { import("ipfsd-ctl").TestsInterface } TestsInterface */
+/** @typedef { import("ipfsd-ctl/src/factory") } Factory */
 /**
- * @param {TestsInterface} common
+ * @param {Factory} common
  * @param {Object} options
  */
 module.exports = (common, options) => {
@@ -23,15 +23,11 @@ module.exports = (common, options) => {
 
     let ipfs
 
-    before(async function () {
-      // CI takes longer to instantiate the daemon, so we need to increase the
-      // timeout for the before step
-      this.timeout(60 * 1000)
-
-      ipfs = await common.setup()
+    before(async () => {
+      ipfs = (await common.spawn()).api
     })
 
-    after(() => common.teardown())
+    after(() => common.clean())
 
     it('should get object by multihash', async () => {
       const obj = {

--- a/src/object/links.js
+++ b/src/object/links.js
@@ -8,10 +8,14 @@ const { getDescribe, getIt, expect } = require('../utils/mocha')
 const { asDAGLink } = require('./utils')
 const CID = require('cids')
 
-module.exports = (createCommon, options) => {
+/** @typedef { import("ipfsd-ctl").TestsInterface } TestsInterface */
+/**
+ * @param {TestsInterface} common
+ * @param {Object} options
+ */
+module.exports = (common, options) => {
   const describe = getDescribe(options)
   const it = getIt(options)
-  const common = createCommon()
 
   describe('.object.links', function () {
     this.timeout(80 * 1000)

--- a/src/object/links.js
+++ b/src/object/links.js
@@ -8,9 +8,9 @@ const { getDescribe, getIt, expect } = require('../utils/mocha')
 const { asDAGLink } = require('./utils')
 const CID = require('cids')
 
-/** @typedef { import("ipfsd-ctl").TestsInterface } TestsInterface */
+/** @typedef { import("ipfsd-ctl/src/factory") } Factory */
 /**
- * @param {TestsInterface} common
+ * @param {Factory} common
  * @param {Object} options
  */
 module.exports = (common, options) => {
@@ -22,15 +22,11 @@ module.exports = (common, options) => {
 
     let ipfs
 
-    before(async function () {
-      // CI takes longer to instantiate the daemon, so we need to increase the
-      // timeout for the before step
-      this.timeout(60 * 1000)
-
-      ipfs = await common.setup()
+    before(async () => {
+      ipfs = (await common.spawn()).api
     })
 
-    after(() => common.teardown())
+    after(() => common.clean())
 
     it('should get empty links by multihash', async () => {
       const testObj = {

--- a/src/object/new.js
+++ b/src/object/new.js
@@ -3,10 +3,14 @@
 
 const { getDescribe, getIt, expect } = require('../utils/mocha')
 
-module.exports = (createCommon, options) => {
+/** @typedef { import("ipfsd-ctl").TestsInterface } TestsInterface */
+/**
+ * @param {TestsInterface} common
+ * @param {Object} options
+ */
+module.exports = (common, options) => {
   const describe = getDescribe(options)
   const it = getIt(options)
-  const common = createCommon()
 
   describe('.object.new', function () {
     this.timeout(80 * 1000)

--- a/src/object/new.js
+++ b/src/object/new.js
@@ -3,9 +3,9 @@
 
 const { getDescribe, getIt, expect } = require('../utils/mocha')
 
-/** @typedef { import("ipfsd-ctl").TestsInterface } TestsInterface */
+/** @typedef { import("ipfsd-ctl/src/factory") } Factory */
 /**
- * @param {TestsInterface} common
+ * @param {Factory} common
  * @param {Object} options
  */
 module.exports = (common, options) => {
@@ -17,15 +17,11 @@ module.exports = (common, options) => {
 
     let ipfs
 
-    before(async function () {
-      // CI takes longer to instantiate the daemon, so we need to increase the
-      // timeout for the before step
-      this.timeout(60 * 1000)
-
-      ipfs = await common.setup()
+    before(async () => {
+      ipfs = (await common.spawn()).api
     })
 
-    after(() => common.teardown())
+    after(() => common.clean())
 
     it('should create a new object with no template', async () => {
       const cid = await ipfs.object.new()

--- a/src/object/patch/add-link.js
+++ b/src/object/patch/add-link.js
@@ -6,9 +6,9 @@ const DAGNode = dagPB.DAGNode
 const { getDescribe, getIt, expect } = require('../../utils/mocha')
 const { asDAGLink } = require('../utils')
 
-/** @typedef { import("ipfsd-ctl").TestsInterface } TestsInterface */
+/** @typedef { import("ipfsd-ctl/src/factory") } Factory */
 /**
- * @param {TestsInterface} common
+ * @param {Factory} common
  * @param {Object} options
  */
 module.exports = (common, options) => {
@@ -20,15 +20,11 @@ module.exports = (common, options) => {
 
     let ipfs
 
-    before(async function () {
-      // CI takes longer to instantiate the daemon, so we need to increase the
-      // timeout for the before step
-      this.timeout(60 * 1000)
-
-      ipfs = await common.setup()
+    before(async () => {
+      ipfs = (await common.spawn()).api
     })
 
-    after(() => common.teardown())
+    after(() => common.clean())
 
     it('should add a link to an existing node', async () => {
       const obj = {

--- a/src/object/patch/add-link.js
+++ b/src/object/patch/add-link.js
@@ -6,10 +6,14 @@ const DAGNode = dagPB.DAGNode
 const { getDescribe, getIt, expect } = require('../../utils/mocha')
 const { asDAGLink } = require('../utils')
 
-module.exports = (createCommon, options) => {
+/** @typedef { import("ipfsd-ctl").TestsInterface } TestsInterface */
+/**
+ * @param {TestsInterface} common
+ * @param {Object} options
+ */
+module.exports = (common, options) => {
   const describe = getDescribe(options)
   const it = getIt(options)
-  const common = createCommon()
 
   describe('.object.patch.addLink', function () {
     this.timeout(80 * 1000)

--- a/src/object/patch/append-data.js
+++ b/src/object/patch/append-data.js
@@ -3,10 +3,14 @@
 
 const { getDescribe, getIt, expect } = require('../../utils/mocha')
 
-module.exports = (createCommon, options) => {
+/** @typedef { import("ipfsd-ctl").TestsInterface } TestsInterface */
+/**
+ * @param {TestsInterface} common
+ * @param {Object} options
+ */
+module.exports = (common, options) => {
   const describe = getDescribe(options)
   const it = getIt(options)
-  const common = createCommon()
 
   describe('.object.patch.appendData', function () {
     this.timeout(80 * 1000)

--- a/src/object/patch/append-data.js
+++ b/src/object/patch/append-data.js
@@ -3,9 +3,9 @@
 
 const { getDescribe, getIt, expect } = require('../../utils/mocha')
 
-/** @typedef { import("ipfsd-ctl").TestsInterface } TestsInterface */
+/** @typedef { import("ipfsd-ctl/src/factory") } Factory */
 /**
- * @param {TestsInterface} common
+ * @param {Factory} common
  * @param {Object} options
  */
 module.exports = (common, options) => {
@@ -17,15 +17,11 @@ module.exports = (common, options) => {
 
     let ipfs
 
-    before(async function () {
-      // CI takes longer to instantiate the daemon, so we need to increase the
-      // timeout for the before step
-      this.timeout(60 * 1000)
-
-      ipfs = await common.setup()
+    before(async () => {
+      ipfs = (await common.spawn()).api
     })
 
-    after(() => common.teardown())
+    after(() => common.clean())
 
     it('should append data to an existing node', async () => {
       const obj = {

--- a/src/object/patch/rm-link.js
+++ b/src/object/patch/rm-link.js
@@ -4,10 +4,14 @@
 const { getDescribe, getIt, expect } = require('../../utils/mocha')
 const { asDAGLink } = require('../utils')
 
-module.exports = (createCommon, options) => {
+/** @typedef { import("ipfsd-ctl").TestsInterface } TestsInterface */
+/**
+ * @param {TestsInterface} common
+ * @param {Object} options
+ */
+module.exports = (common, options) => {
   const describe = getDescribe(options)
   const it = getIt(options)
-  const common = createCommon()
 
   describe('.object.patch.rmLink', function () {
     this.timeout(80 * 1000)

--- a/src/object/patch/rm-link.js
+++ b/src/object/patch/rm-link.js
@@ -4,9 +4,9 @@
 const { getDescribe, getIt, expect } = require('../../utils/mocha')
 const { asDAGLink } = require('../utils')
 
-/** @typedef { import("ipfsd-ctl").TestsInterface } TestsInterface */
+/** @typedef { import("ipfsd-ctl/src/factory") } Factory */
 /**
- * @param {TestsInterface} common
+ * @param {Factory} common
  * @param {Object} options
  */
 module.exports = (common, options) => {
@@ -18,15 +18,11 @@ module.exports = (common, options) => {
 
     let ipfs
 
-    before(async function () {
-      // CI takes longer to instantiate the daemon, so we need to increase the
-      // timeout for the before step
-      this.timeout(60 * 1000)
-
-      ipfs = await common.setup()
+    before(async () => {
+      ipfs = (await common.spawn()).api
     })
 
-    after(() => common.teardown())
+    after(() => common.clean())
 
     it('should remove a link from an existing node', async () => {
       const obj1 = {

--- a/src/object/patch/set-data.js
+++ b/src/object/patch/set-data.js
@@ -3,10 +3,14 @@
 
 const { getDescribe, getIt, expect } = require('../../utils/mocha')
 
-module.exports = (createCommon, options) => {
+/** @typedef { import("ipfsd-ctl").TestsInterface } TestsInterface */
+/**
+ * @param {TestsInterface} common
+ * @param {Object} options
+ */
+module.exports = (common, options) => {
   const describe = getDescribe(options)
   const it = getIt(options)
-  const common = createCommon()
 
   describe('.object.patch.setData', function () {
     this.timeout(80 * 1000)

--- a/src/object/patch/set-data.js
+++ b/src/object/patch/set-data.js
@@ -3,9 +3,9 @@
 
 const { getDescribe, getIt, expect } = require('../../utils/mocha')
 
-/** @typedef { import("ipfsd-ctl").TestsInterface } TestsInterface */
+/** @typedef { import("ipfsd-ctl/src/factory") } Factory */
 /**
- * @param {TestsInterface} common
+ * @param {Factory} common
  * @param {Object} options
  */
 module.exports = (common, options) => {
@@ -17,15 +17,11 @@ module.exports = (common, options) => {
 
     let ipfs
 
-    before(async function () {
-      // CI takes longer to instantiate the daemon, so we need to increase the
-      // timeout for the before step
-      this.timeout(60 * 1000)
-
-      ipfs = await common.setup()
+    before(async () => {
+      ipfs = (await common.spawn()).api
     })
 
-    after(() => common.teardown())
+    after(() => common.clean())
 
     it('should set data for an existing node', async () => {
       const obj = {

--- a/src/object/put.js
+++ b/src/object/put.js
@@ -7,10 +7,14 @@ const hat = require('hat')
 const { getDescribe, getIt, expect } = require('../utils/mocha')
 const { asDAGLink } = require('./utils')
 
-module.exports = (createCommon, options) => {
+/** @typedef { import("ipfsd-ctl").TestsInterface } TestsInterface */
+/**
+ * @param {TestsInterface} common
+ * @param {Object} options
+ */
+module.exports = (common, options) => {
   const describe = getDescribe(options)
   const it = getIt(options)
-  const common = createCommon()
 
   describe('.object.put', function () {
     this.timeout(80 * 1000)

--- a/src/object/put.js
+++ b/src/object/put.js
@@ -7,9 +7,9 @@ const hat = require('hat')
 const { getDescribe, getIt, expect } = require('../utils/mocha')
 const { asDAGLink } = require('./utils')
 
-/** @typedef { import("ipfsd-ctl").TestsInterface } TestsInterface */
+/** @typedef { import("ipfsd-ctl/src/factory") } Factory */
 /**
- * @param {TestsInterface} common
+ * @param {Factory} common
  * @param {Object} options
  */
 module.exports = (common, options) => {
@@ -21,15 +21,11 @@ module.exports = (common, options) => {
 
     let ipfs
 
-    before(async function () {
-      // CI takes longer to instantiate the daemon, so we need to increase the
-      // timeout for the before step
-      this.timeout(60 * 1000)
-
-      ipfs = await common.setup()
+    before(async () => {
+      ipfs = (await common.spawn()).api
     })
 
-    after(() => common.teardown())
+    after(() => common.clean())
 
     it('should put an object', async () => {
       const obj = {

--- a/src/object/stat.js
+++ b/src/object/stat.js
@@ -6,10 +6,14 @@ const DAGNode = dagPB.DAGNode
 const { getDescribe, getIt, expect } = require('../utils/mocha')
 const { asDAGLink } = require('./utils')
 
-module.exports = (createCommon, options) => {
+/** @typedef { import("ipfsd-ctl").TestsInterface } TestsInterface */
+/**
+ * @param {TestsInterface} common
+ * @param {Object} options
+ */
+module.exports = (common, options) => {
   const describe = getDescribe(options)
   const it = getIt(options)
-  const common = createCommon()
 
   describe('.object.stat', function () {
     this.timeout(80 * 1000)

--- a/src/object/stat.js
+++ b/src/object/stat.js
@@ -6,9 +6,9 @@ const DAGNode = dagPB.DAGNode
 const { getDescribe, getIt, expect } = require('../utils/mocha')
 const { asDAGLink } = require('./utils')
 
-/** @typedef { import("ipfsd-ctl").TestsInterface } TestsInterface */
+/** @typedef { import("ipfsd-ctl/src/factory") } Factory */
 /**
- * @param {TestsInterface} common
+ * @param {Factory} common
  * @param {Object} options
  */
 module.exports = (common, options) => {
@@ -20,15 +20,11 @@ module.exports = (common, options) => {
 
     let ipfs
 
-    before(async function () {
-      // CI takes longer to instantiate the daemon, so we need to increase the
-      // timeout for the before step
-      this.timeout(60 * 1000)
-
-      ipfs = await common.setup()
+    before(async () => {
+      ipfs = (await common.spawn()).api
     })
 
-    after(() => common.teardown())
+    after(() => common.clean())
 
     it('should get stats by multihash', async () => {
       const testObj = {

--- a/src/pin/add.js
+++ b/src/pin/add.js
@@ -4,9 +4,9 @@
 const { fixtures } = require('./utils')
 const { getDescribe, getIt, expect } = require('../utils/mocha')
 
-/** @typedef { import("ipfsd-ctl").TestsInterface } TestsInterface */
+/** @typedef { import("ipfsd-ctl/src/factory") } Factory */
 /**
- * @param {TestsInterface} common
+ * @param {Factory} common
  * @param {Object} options
  */
 module.exports = (common, options) => {
@@ -18,13 +18,13 @@ module.exports = (common, options) => {
 
     let ipfs
     before(async () => {
-      ipfs = await common.setup()
+      ipfs = (await common.spawn()).api
       await Promise.all(fixtures.files.map(file => {
         return ipfs.add(file.data, { pin: false })
       }))
     })
 
-    after(() => common.teardown())
+    after(() => common.clean())
 
     it('should add a pin', async () => {
       const pinset = await ipfs.pin.add(fixtures.files[0].cid, { recursive: false })

--- a/src/pin/add.js
+++ b/src/pin/add.js
@@ -4,21 +4,20 @@
 const { fixtures } = require('./utils')
 const { getDescribe, getIt, expect } = require('../utils/mocha')
 
-module.exports = (createCommon, options) => {
+/** @typedef { import("ipfsd-ctl").TestsInterface } TestsInterface */
+/**
+ * @param {TestsInterface} common
+ * @param {Object} options
+ */
+module.exports = (common, options) => {
   const describe = getDescribe(options)
   const it = getIt(options)
-  const common = createCommon()
 
   describe('.pin.add', function () {
     this.timeout(50 * 1000)
 
     let ipfs
-
-    before(async function () {
-      // CI takes longer to instantiate the daemon, so we need to increase the
-      // timeout for the before step
-      this.timeout(60 * 1000)
-
+    before(async () => {
       ipfs = await common.setup()
       await Promise.all(fixtures.files.map(file => {
         return ipfs.add(file.data, { pin: false })

--- a/src/pin/ls.js
+++ b/src/pin/ls.js
@@ -4,10 +4,14 @@
 const { fixtures } = require('./utils')
 const { getDescribe, getIt, expect } = require('../utils/mocha')
 
-module.exports = (createCommon, options) => {
+/** @typedef { import("ipfsd-ctl").TestsInterface } TestsInterface */
+/**
+ * @param {TestsInterface} common
+ * @param {Object} options
+ */
+module.exports = (common, options) => {
   const describe = getDescribe(options)
   const it = getIt(options)
-  const common = createCommon()
 
   describe('.pin.ls', function () {
     this.timeout(50 * 1000)

--- a/src/pin/ls.js
+++ b/src/pin/ls.js
@@ -4,9 +4,9 @@
 const { fixtures } = require('./utils')
 const { getDescribe, getIt, expect } = require('../utils/mocha')
 
-/** @typedef { import("ipfsd-ctl").TestsInterface } TestsInterface */
+/** @typedef { import("ipfsd-ctl/src/factory") } Factory */
 /**
- * @param {TestsInterface} common
+ * @param {Factory} common
  * @param {Object} options
  */
 module.exports = (common, options) => {
@@ -18,12 +18,8 @@ module.exports = (common, options) => {
 
     let ipfs
 
-    before(async function () {
-      // CI takes longer to instantiate the daemon, so we need to increase the
-      // timeout for the before step
-      this.timeout(60 * 1000)
-
-      ipfs = await common.setup()
+    before(async () => {
+      ipfs = (await common.spawn()).api
       // two files wrapped in directories, only root CID pinned recursively
       const dir = fixtures.directory.files.map((file) => ({ path: file.path, content: file.data }))
       await ipfs.add(dir, { pin: false, cidVersion: 0 })
@@ -36,7 +32,7 @@ module.exports = (common, options) => {
       await ipfs.pin.add(fixtures.files[1].cid, { recursive: false })
     })
 
-    after(() => common.teardown())
+    after(() => common.clean())
 
     // 1st, because ipfs.add pins automatically
     it('should list all recursive pins', async () => {

--- a/src/pin/rm.js
+++ b/src/pin/rm.js
@@ -4,9 +4,9 @@
 const { fixtures } = require('./utils')
 const { getDescribe, getIt, expect } = require('../utils/mocha')
 
-/** @typedef { import("ipfsd-ctl").TestsInterface } TestsInterface */
+/** @typedef { import("ipfsd-ctl/src/factory") } Factory */
 /**
- * @param {TestsInterface} common
+ * @param {Factory} common
  * @param {Object} options
  */
 module.exports = (common, options) => {
@@ -18,14 +18,14 @@ module.exports = (common, options) => {
 
     let ipfs
     before(async () => {
-      ipfs = await common.setup()
+      ipfs = (await common.spawn()).api
       await ipfs.add(fixtures.files[0].data, { pin: false })
       await ipfs.pin.add(fixtures.files[0].cid, { recursive: true })
       await ipfs.add(fixtures.files[1].data, { pin: false })
       await ipfs.pin.add(fixtures.files[1].cid, { recursive: false })
     })
 
-    after(() => common.teardown())
+    after(() => common.clean())
 
     it('should remove a recursive pin', async () => {
       const removedPinset = await ipfs.pin.rm(fixtures.files[0].cid, { recursive: true })

--- a/src/pin/rm.js
+++ b/src/pin/rm.js
@@ -4,21 +4,20 @@
 const { fixtures } = require('./utils')
 const { getDescribe, getIt, expect } = require('../utils/mocha')
 
-module.exports = (createCommon, options) => {
+/** @typedef { import("ipfsd-ctl").TestsInterface } TestsInterface */
+/**
+ * @param {TestsInterface} common
+ * @param {Object} options
+ */
+module.exports = (common, options) => {
   const describe = getDescribe(options)
   const it = getIt(options)
-  const common = createCommon()
 
   describe('.pin.rm', function () {
     this.timeout(50 * 1000)
 
     let ipfs
-
-    before(async function () {
-      // CI takes longer to instantiate the daemon, so we need to increase the
-      // timeout for the before step
-      this.timeout(60 * 1000)
-
+    before(async () => {
       ipfs = await common.setup()
       await ipfs.add(fixtures.files[0].data, { pin: false })
       await ipfs.pin.add(fixtures.files[0].cid, { recursive: true })

--- a/src/ping/ping-pull-stream.js
+++ b/src/ping/ping-pull-stream.js
@@ -5,9 +5,9 @@ const pullToPromise = require('pull-to-promise')
 const { getDescribe, getIt, expect } = require('../utils/mocha')
 const { isPong } = require('./utils.js')
 
-/** @typedef { import("ipfsd-ctl").TestsInterface } TestsInterface */
+/** @typedef { import("ipfsd-ctl/src/factory") } Factory */
 /**
- * @param {TestsInterface} common
+ * @param {Factory} common
  * @param {Object} options
  */
 module.exports = (common, options) => {
@@ -21,12 +21,12 @@ module.exports = (common, options) => {
     let ipfsB
 
     before(async () => {
-      ipfsA = await common.setup()
-      ipfsB = await common.setup({ type: 'js' })
+      ipfsA = (await common.spawn()).api
+      ipfsB = (await common.spawn({ type: 'js' })).api
       await ipfsA.swarm.connect(ipfsB.peerId.addresses[0])
     })
 
-    after(() => common.teardown())
+    after(() => common.clean())
 
     it('should send the specified number of packets over pull stream', async () => {
       const count = 3

--- a/src/ping/ping-pull-stream.js
+++ b/src/ping/ping-pull-stream.js
@@ -5,10 +5,14 @@ const pullToPromise = require('pull-to-promise')
 const { getDescribe, getIt, expect } = require('../utils/mocha')
 const { isPong } = require('./utils.js')
 
-module.exports = (createCommon, options) => {
+/** @typedef { import("ipfsd-ctl").TestsInterface } TestsInterface */
+/**
+ * @param {TestsInterface} common
+ * @param {Object} options
+ */
+module.exports = (common, options) => {
   const describe = getDescribe(options)
   const it = getIt(options)
-  const common = createCommon()
 
   describe('.pingPullStream', function () {
     this.timeout(60 * 1000)

--- a/src/ping/ping-pull-stream.js
+++ b/src/ping/ping-pull-stream.js
@@ -22,7 +22,7 @@ module.exports = (common, options) => {
 
     before(async () => {
       ipfsA = await common.setup()
-      ipfsB = await common.setup()
+      ipfsB = await common.setup({ type: 'js' })
       await ipfsA.swarm.connect(ipfsB.peerId.addresses[0])
     })
 

--- a/src/ping/ping-readable-stream.js
+++ b/src/ping/ping-readable-stream.js
@@ -6,9 +6,9 @@ const { Writable } = require('stream')
 const { getDescribe, getIt, expect } = require('../utils/mocha')
 const { isPong } = require('./utils.js')
 
-/** @typedef { import("ipfsd-ctl").TestsInterface } TestsInterface */
+/** @typedef { import("ipfsd-ctl/src/factory") } Factory */
 /**
- * @param {TestsInterface} common
+ * @param {Factory} common
  * @param {Object} options
  */
 module.exports = (common, options) => {
@@ -22,12 +22,12 @@ module.exports = (common, options) => {
     let ipfsB
 
     before(async () => {
-      ipfsA = await common.setup()
-      ipfsB = await common.setup({ type: 'js' })
+      ipfsA = (await common.spawn()).api
+      ipfsB = (await common.spawn({ type: 'js' })).api
       await ipfsA.swarm.connect(ipfsB.peerId.addresses[0])
     })
 
-    after(() => common.teardown())
+    after(() => common.clean())
 
     it('should send the specified number of packets over readable stream', () => {
       let packetNum = 0

--- a/src/ping/ping-readable-stream.js
+++ b/src/ping/ping-readable-stream.js
@@ -6,10 +6,14 @@ const { Writable } = require('stream')
 const { getDescribe, getIt, expect } = require('../utils/mocha')
 const { isPong } = require('./utils.js')
 
-module.exports = (createCommon, options) => {
+/** @typedef { import("ipfsd-ctl").TestsInterface } TestsInterface */
+/**
+ * @param {TestsInterface} common
+ * @param {Object} options
+ */
+module.exports = (common, options) => {
   const describe = getDescribe(options)
   const it = getIt(options)
-  const common = createCommon()
 
   describe('.pingReadableStream', function () {
     this.timeout(60 * 1000)

--- a/src/ping/ping-readable-stream.js
+++ b/src/ping/ping-readable-stream.js
@@ -23,7 +23,7 @@ module.exports = (common, options) => {
 
     before(async () => {
       ipfsA = await common.setup()
-      ipfsB = await common.setup()
+      ipfsB = await common.setup({ type: 'js' })
       await ipfsA.swarm.connect(ipfsB.peerId.addresses[0])
     })
 

--- a/src/ping/ping.js
+++ b/src/ping/ping.js
@@ -4,10 +4,14 @@
 const { getDescribe, getIt, expect } = require('../utils/mocha')
 const { expectIsPingResponse, isPong } = require('./utils')
 
-module.exports = (createCommon, options) => {
+/** @typedef { import("ipfsd-ctl").TestsInterface } TestsInterface */
+/**
+ * @param {TestsInterface} common
+ * @param {Object} options
+ */
+module.exports = (common, options) => {
   const describe = getDescribe(options)
   const it = getIt(options)
-  const common = createCommon()
 
   describe('.ping', function () {
     this.timeout(60 * 1000)

--- a/src/ping/ping.js
+++ b/src/ping/ping.js
@@ -4,9 +4,9 @@
 const { getDescribe, getIt, expect } = require('../utils/mocha')
 const { expectIsPingResponse, isPong } = require('./utils')
 
-/** @typedef { import("ipfsd-ctl").TestsInterface } TestsInterface */
+/** @typedef { import("ipfsd-ctl/src/factory") } Factory */
 /**
- * @param {TestsInterface} common
+ * @param {Factory} common
  * @param {Object} options
  */
 module.exports = (common, options) => {
@@ -19,17 +19,13 @@ module.exports = (common, options) => {
     let ipfsA
     let ipfsB
 
-    before(async function () {
-      // CI takes longer to instantiate the daemon, so we need to increase the
-      // timeout for the before step
-      this.timeout(60 * 1000)
-
-      ipfsA = await common.setup()
-      ipfsB = await common.setup({ type: 'js' })
+    before(async () => {
+      ipfsA = (await common.spawn()).api
+      ipfsB = (await common.spawn({ type: 'js' })).api
       await ipfsA.swarm.connect(ipfsB.peerId.addresses[0])
     })
 
-    after(() => common.teardown())
+    after(() => common.clean())
 
     it('should send the specified number of packets', async () => {
       const count = 3

--- a/src/ping/ping.js
+++ b/src/ping/ping.js
@@ -25,7 +25,7 @@ module.exports = (common, options) => {
       this.timeout(60 * 1000)
 
       ipfsA = await common.setup()
-      ipfsB = await common.setup()
+      ipfsB = await common.setup({ type: 'js' })
       await ipfsA.swarm.connect(ipfsB.peerId.addresses[0])
     })
 

--- a/src/pubsub/ls.js
+++ b/src/pubsub/ls.js
@@ -5,9 +5,9 @@ const { getTopic } = require('./utils')
 const { getDescribe, getIt, expect } = require('../utils/mocha')
 const delay = require('delay')
 
-/** @typedef { import("ipfsd-ctl").TestsInterface } TestsInterface */
+/** @typedef { import("ipfsd-ctl/src/factory") } Factory */
 /**
- * @param {TestsInterface} common
+ * @param {Factory} common
  * @param {Object} options
  */
 module.exports = (common, options) => {
@@ -20,7 +20,7 @@ module.exports = (common, options) => {
     let ipfs
     let subscribedTopics = []
     before(async () => {
-      ipfs = await common.setup()
+      ipfs = (await common.spawn()).api
     })
 
     afterEach(async () => {
@@ -31,7 +31,7 @@ module.exports = (common, options) => {
       await delay(100)
     })
 
-    after(() => common.teardown())
+    after(() => common.clean())
 
     it('should return an empty list when no topics are subscribed', async () => {
       const topics = await ipfs.pubsub.ls()

--- a/src/pubsub/ls.js
+++ b/src/pubsub/ls.js
@@ -5,22 +5,21 @@ const { getTopic } = require('./utils')
 const { getDescribe, getIt, expect } = require('../utils/mocha')
 const delay = require('delay')
 
-module.exports = (createCommon, options) => {
+/** @typedef { import("ipfsd-ctl").TestsInterface } TestsInterface */
+/**
+ * @param {TestsInterface} common
+ * @param {Object} options
+ */
+module.exports = (common, options) => {
   const describe = getDescribe(options)
   const it = getIt(options)
-  const common = createCommon()
 
   describe('.pubsub.ls', function () {
     this.timeout(80 * 1000)
 
     let ipfs
     let subscribedTopics = []
-
-    before(async function () {
-      // CI takes longer to instantiate the daemon, so we need to increase the
-      // timeout for the before step
-      this.timeout(60 * 1000)
-
+    before(async () => {
       ipfs = await common.setup()
     })
 

--- a/src/pubsub/peers.js
+++ b/src/pubsub/peers.js
@@ -5,9 +5,9 @@ const { waitForPeers, getTopic } = require('./utils')
 const { getDescribe, getIt, expect } = require('../utils/mocha')
 const delay = require('delay')
 
-/** @typedef { import("ipfsd-ctl").TestsInterface } TestsInterface */
+/** @typedef { import("ipfsd-ctl/src/factory") } Factory */
 /**
- * @param {TestsInterface} common
+ * @param {Factory} common
  * @param {Object} options
  */
 module.exports = (common, options) => {
@@ -22,9 +22,9 @@ module.exports = (common, options) => {
     let ipfs3
     let subscribedTopics = []
     before(async () => {
-      ipfs1 = await common.setup()
-      ipfs2 = await common.setup({ type: 'go' })
-      ipfs3 = await common.setup({ type: 'go' })
+      ipfs1 = (await common.spawn()).api
+      ipfs2 = (await common.spawn({ type: 'go' })).api
+      ipfs3 = (await common.spawn({ type: 'go' })).api
 
       const ipfs2Addr = ipfs2.peerId.addresses.find((a) => a.includes('127.0.0.1'))
       const ipfs3Addr = ipfs3.peerId.addresses.find((a) => a.includes('127.0.0.1'))
@@ -44,7 +44,7 @@ module.exports = (common, options) => {
       await delay(100)
     })
 
-    after(() => common.teardown())
+    after(() => common.clean())
 
     it('should not error when not subscribed to a topic', async () => {
       const topic = getTopic()

--- a/src/pubsub/peers.js
+++ b/src/pubsub/peers.js
@@ -23,8 +23,8 @@ module.exports = (common, options) => {
     let subscribedTopics = []
     before(async () => {
       ipfs1 = await common.setup()
-      ipfs2 = await common.setup()
-      ipfs3 = await common.setup()
+      ipfs2 = await common.setup({ type: 'js' })
+      ipfs3 = await common.setup({ type: 'js' })
 
       const ipfs2Addr = ipfs2.peerId.addresses.find((a) => a.includes('127.0.0.1'))
       const ipfs3Addr = ipfs3.peerId.addresses.find((a) => a.includes('127.0.0.1'))

--- a/src/pubsub/peers.js
+++ b/src/pubsub/peers.js
@@ -23,8 +23,8 @@ module.exports = (common, options) => {
     let subscribedTopics = []
     before(async () => {
       ipfs1 = await common.setup()
-      ipfs2 = await common.setup({ type: 'js' })
-      ipfs3 = await common.setup({ type: 'js' })
+      ipfs2 = await common.setup({ type: 'go' })
+      ipfs3 = await common.setup({ type: 'go' })
 
       const ipfs2Addr = ipfs2.peerId.addresses.find((a) => a.includes('127.0.0.1'))
       const ipfs3Addr = ipfs3.peerId.addresses.find((a) => a.includes('127.0.0.1'))

--- a/src/pubsub/peers.js
+++ b/src/pubsub/peers.js
@@ -5,10 +5,14 @@ const { waitForPeers, getTopic } = require('./utils')
 const { getDescribe, getIt, expect } = require('../utils/mocha')
 const delay = require('delay')
 
-module.exports = (createCommon, options) => {
+/** @typedef { import("ipfsd-ctl").TestsInterface } TestsInterface */
+/**
+ * @param {TestsInterface} common
+ * @param {Object} options
+ */
+module.exports = (common, options) => {
   const describe = getDescribe(options)
   const it = getIt(options)
-  const common = createCommon()
 
   describe('.pubsub.peers', function () {
     this.timeout(80 * 1000)
@@ -17,12 +21,7 @@ module.exports = (createCommon, options) => {
     let ipfs2
     let ipfs3
     let subscribedTopics = []
-
-    before(async function () {
-      // CI takes longer to instantiate the daemon, so we need to increase the
-      // timeout for the before step
-      this.timeout(100 * 1000)
-
+    before(async () => {
       ipfs1 = await common.setup()
       ipfs2 = await common.setup()
       ipfs3 = await common.setup()

--- a/src/pubsub/publish.js
+++ b/src/pubsub/publish.js
@@ -5,9 +5,9 @@ const hat = require('hat')
 const { getTopic } = require('./utils')
 const { getDescribe, getIt } = require('../utils/mocha')
 
-/** @typedef { import("ipfsd-ctl").TestsInterface } TestsInterface */
+/** @typedef { import("ipfsd-ctl/src/factory") } Factory */
 /**
- * @param {TestsInterface} common
+ * @param {Factory} common
  * @param {Object} options
  */
 module.exports = (common, options) => {
@@ -19,15 +19,11 @@ module.exports = (common, options) => {
 
     let ipfs
 
-    before(async function () {
-      // CI takes longer to instantiate the daemon, so we need to increase the
-      // timeout for the before step
-      this.timeout(60 * 1000)
-
-      ipfs = await common.setup()
+    before(async () => {
+      ipfs = (await common.spawn()).api
     })
 
-    after(() => common.teardown())
+    after(() => common.clean())
 
     it('should publish message from string', () => {
       const topic = getTopic()

--- a/src/pubsub/publish.js
+++ b/src/pubsub/publish.js
@@ -5,10 +5,14 @@ const hat = require('hat')
 const { getTopic } = require('./utils')
 const { getDescribe, getIt } = require('../utils/mocha')
 
-module.exports = (createCommon, options) => {
+/** @typedef { import("ipfsd-ctl").TestsInterface } TestsInterface */
+/**
+ * @param {TestsInterface} common
+ * @param {Object} options
+ */
+module.exports = (common, options) => {
   const describe = getDescribe(options)
   const it = getIt(options)
-  const common = createCommon()
 
   describe('.pubsub.publish', function () {
     this.timeout(80 * 1000)

--- a/src/pubsub/subscribe.js
+++ b/src/pubsub/subscribe.js
@@ -30,7 +30,7 @@ module.exports = (common, options) => {
       this.timeout(100 * 1000)
 
       ipfs1 = await common.setup()
-      ipfs2 = await common.setup()
+      ipfs2 = await common.setup({ type: 'js' })
     })
 
     after(() => common.teardown())

--- a/src/pubsub/subscribe.js
+++ b/src/pubsub/subscribe.js
@@ -7,9 +7,9 @@ const { waitForPeers, getTopic } = require('./utils')
 const { getDescribe, getIt, expect } = require('../utils/mocha')
 const delay = require('delay')
 
-/** @typedef { import("ipfsd-ctl").TestsInterface } TestsInterface */
+/** @typedef { import("ipfsd-ctl/src/factory") } Factory */
 /**
- * @param {TestsInterface} common
+ * @param {Factory} common
  * @param {Object} options
  */
 module.exports = (common, options) => {
@@ -24,13 +24,9 @@ module.exports = (common, options) => {
     let topic
     let subscribedTopics = []
 
-    before(async function () {
-      // CI takes longer to instantiate the daemon, so we need to increase the
-      // timeout for the before step
-      this.timeout(100 * 1000)
-
-      ipfs1 = await common.setup()
-      ipfs2 = await common.setup({ type: 'go' })
+    before(async () => {
+      ipfs1 = (await common.spawn()).api
+      ipfs2 = (await common.spawn({ type: 'go' })).api
     })
 
     beforeEach(() => {
@@ -48,7 +44,7 @@ module.exports = (common, options) => {
       await delay(100)
     })
 
-    after(() => common.teardown())
+    after(() => common.clean())
 
     describe('single node', () => {
       it('should subscribe to one topic', async () => {

--- a/src/pubsub/subscribe.js
+++ b/src/pubsub/subscribe.js
@@ -26,7 +26,8 @@ module.exports = (common, options) => {
 
     before(async () => {
       ipfs1 = (await common.spawn()).api
-      ipfs2 = (await common.spawn({ type: 'go' })).api
+      // TODO 'multiple connected nodes' tests fails with go in Firefox
+      ipfs2 = (await common.spawn({ type: 'js' })).api
     })
 
     beforeEach(() => {

--- a/src/pubsub/subscribe.js
+++ b/src/pubsub/subscribe.js
@@ -30,10 +30,8 @@ module.exports = (common, options) => {
       this.timeout(100 * 1000)
 
       ipfs1 = await common.setup()
-      ipfs2 = await common.setup({ type: 'js' })
+      ipfs2 = await common.setup({ type: 'go' })
     })
-
-    after(() => common.teardown())
 
     beforeEach(() => {
       topic = getTopic()

--- a/src/pubsub/subscribe.js
+++ b/src/pubsub/subscribe.js
@@ -27,7 +27,7 @@ module.exports = (common, options) => {
     before(async () => {
       ipfs1 = (await common.spawn()).api
       // TODO 'multiple connected nodes' tests fails with go in Firefox
-      ipfs2 = (await common.spawn({ type: 'js' })).api
+      ipfs2 = (await common.spawn({ type: 'go' })).api
     })
 
     beforeEach(() => {

--- a/src/pubsub/subscribe.js
+++ b/src/pubsub/subscribe.js
@@ -27,6 +27,7 @@ module.exports = (common, options) => {
     before(async () => {
       ipfs1 = (await common.spawn()).api
       // TODO 'multiple connected nodes' tests fails with go in Firefox
+      // and JS is flaky everywhere
       ipfs2 = (await common.spawn({ type: 'go' })).api
     })
 

--- a/src/pubsub/subscribe.js
+++ b/src/pubsub/subscribe.js
@@ -7,10 +7,14 @@ const { waitForPeers, getTopic } = require('./utils')
 const { getDescribe, getIt, expect } = require('../utils/mocha')
 const delay = require('delay')
 
-module.exports = (createCommon, options) => {
+/** @typedef { import("ipfsd-ctl").TestsInterface } TestsInterface */
+/**
+ * @param {TestsInterface} common
+ * @param {Object} options
+ */
+module.exports = (common, options) => {
   const describe = getDescribe(options)
   const it = getIt(options)
-  const common = createCommon()
 
   describe('.pubsub.subscribe', function () {
     this.timeout(80 * 1000)
@@ -28,6 +32,8 @@ module.exports = (createCommon, options) => {
       ipfs1 = await common.setup()
       ipfs2 = await common.setup()
     })
+
+    after(() => common.teardown())
 
     beforeEach(() => {
       topic = getTopic()

--- a/src/pubsub/unsubscribe.js
+++ b/src/pubsub/unsubscribe.js
@@ -6,9 +6,9 @@ const { getTopic } = require('./utils')
 const { getDescribe, getIt, expect } = require('../utils/mocha')
 const delay = require('delay')
 
-/** @typedef { import("ipfsd-ctl").TestsInterface } TestsInterface */
+/** @typedef { import("ipfsd-ctl/src/factory") } Factory */
 /**
- * @param {TestsInterface} common
+ * @param {Factory} common
  * @param {Object} options
  */
 module.exports = (common, options) => {
@@ -20,15 +20,11 @@ module.exports = (common, options) => {
 
     let ipfs
 
-    before(async function () {
-      // CI takes longer to instantiate the daemon, so we need to increase the
-      // timeout for the before step
-      this.timeout(60 * 1000)
-
-      ipfs = await common.setup()
+    before(async () => {
+      ipfs = (await common.spawn()).api
     })
 
-    after(() => common.teardown())
+    after(() => common.clean())
 
     // Browser/worker has max ~5 open HTTP requests to the same origin
     const count = isBrowser || isWebWorker || isElectronRenderer ? 5 : 10

--- a/src/pubsub/unsubscribe.js
+++ b/src/pubsub/unsubscribe.js
@@ -6,10 +6,14 @@ const { getTopic } = require('./utils')
 const { getDescribe, getIt, expect } = require('../utils/mocha')
 const delay = require('delay')
 
-module.exports = (createCommon, options) => {
+/** @typedef { import("ipfsd-ctl").TestsInterface } TestsInterface */
+/**
+ * @param {TestsInterface} common
+ * @param {Object} options
+ */
+module.exports = (common, options) => {
   const describe = getDescribe(options)
   const it = getIt(options)
-  const common = createCommon()
 
   describe('.pubsub.unsubscribe', function () {
     this.timeout(80 * 1000)

--- a/src/repo/gc.js
+++ b/src/repo/gc.js
@@ -4,10 +4,14 @@
 const { getDescribe, getIt, expect } = require('../utils/mocha')
 const { DAGNode } = require('ipld-dag-pb')
 
-module.exports = (createCommon, options) => {
+/** @typedef { import("ipfsd-ctl").TestsInterface } TestsInterface */
+/**
+ * @param {TestsInterface} common
+ * @param {Object} options
+ */
+module.exports = (common, options) => {
   const describe = getDescribe(options)
   const it = getIt(options)
-  const common = createCommon()
 
   describe('.repo.gc', () => {
     let ipfs

--- a/src/repo/gc.js
+++ b/src/repo/gc.js
@@ -4,9 +4,9 @@
 const { getDescribe, getIt, expect } = require('../utils/mocha')
 const { DAGNode } = require('ipld-dag-pb')
 
-/** @typedef { import("ipfsd-ctl").TestsInterface } TestsInterface */
+/** @typedef { import("ipfsd-ctl/src/factory") } Factory */
 /**
- * @param {TestsInterface} common
+ * @param {Factory} common
  * @param {Object} options
  */
 module.exports = (common, options) => {
@@ -16,15 +16,11 @@ module.exports = (common, options) => {
   describe('.repo.gc', () => {
     let ipfs
 
-    before(async function () {
-      // CI takes longer to instantiate the daemon, so we need to increase the
-      // timeout for the before step
-      this.timeout(60 * 1000)
-
-      ipfs = await common.setup()
+    before(async () => {
+      ipfs = (await common.spawn()).api
     })
 
-    after(() => common.teardown())
+    after(() => common.clean())
 
     it('should run garbage collection', async () => {
       const res = await ipfs.add(Buffer.from('apples'))

--- a/src/repo/stat.js
+++ b/src/repo/stat.js
@@ -4,9 +4,9 @@
 const { expectIsRepo } = require('../stats/utils')
 const { getDescribe, getIt } = require('../utils/mocha')
 
-/** @typedef { import("ipfsd-ctl").TestsInterface } TestsInterface */
+/** @typedef { import("ipfsd-ctl/src/factory") } Factory */
 /**
- * @param {TestsInterface} common
+ * @param {Factory} common
  * @param {Object} options
  */
 module.exports = (common, options) => {
@@ -16,15 +16,11 @@ module.exports = (common, options) => {
   describe('.repo.stat', () => {
     let ipfs
 
-    before(async function () {
-      // CI takes longer to instantiate the daemon, so we need to increase the
-      // timeout for the before step
-      this.timeout(60 * 1000)
-
-      ipfs = await common.setup()
+    before(async () => {
+      ipfs = (await common.spawn()).api
     })
 
-    after(() => common.teardown())
+    after(() => common.clean())
 
     it('should get repo stats', async () => {
       const res = await ipfs.repo.stat()

--- a/src/repo/stat.js
+++ b/src/repo/stat.js
@@ -4,10 +4,14 @@
 const { expectIsRepo } = require('../stats/utils')
 const { getDescribe, getIt } = require('../utils/mocha')
 
-module.exports = (createCommon, options) => {
+/** @typedef { import("ipfsd-ctl").TestsInterface } TestsInterface */
+/**
+ * @param {TestsInterface} common
+ * @param {Object} options
+ */
+module.exports = (common, options) => {
   const describe = getDescribe(options)
   const it = getIt(options)
-  const common = createCommon()
 
   describe('.repo.stat', () => {
     let ipfs

--- a/src/repo/version.js
+++ b/src/repo/version.js
@@ -3,10 +3,14 @@
 
 const { getDescribe, getIt, expect } = require('../utils/mocha')
 
-module.exports = (createCommon, options) => {
+/** @typedef { import("ipfsd-ctl").TestsInterface } TestsInterface */
+/**
+ * @param {TestsInterface} common
+ * @param {Object} options
+ */
+module.exports = (common, options) => {
   const describe = getDescribe(options)
   const it = getIt(options)
-  const common = createCommon()
 
   describe('.repo.version', () => {
     let ipfs

--- a/src/repo/version.js
+++ b/src/repo/version.js
@@ -3,9 +3,9 @@
 
 const { getDescribe, getIt, expect } = require('../utils/mocha')
 
-/** @typedef { import("ipfsd-ctl").TestsInterface } TestsInterface */
+/** @typedef { import("ipfsd-ctl/src/factory") } Factory */
 /**
- * @param {TestsInterface} common
+ * @param {Factory} common
  * @param {Object} options
  */
 module.exports = (common, options) => {
@@ -15,15 +15,11 @@ module.exports = (common, options) => {
   describe('.repo.version', () => {
     let ipfs
 
-    before(async function () {
-      // CI takes longer to instantiate the daemon, so we need to increase the
-      // timeout for the before step
-      this.timeout(60 * 1000)
-
-      ipfs = await common.setup()
+    before(async () => {
+      ipfs = (await common.spawn()).api
     })
 
-    after(() => common.teardown())
+    after(() => common.clean())
 
     it('should get the repo version', async () => {
       const version = await ipfs.repo.version()

--- a/src/stats/bitswap.js
+++ b/src/stats/bitswap.js
@@ -4,9 +4,9 @@
 const { getDescribe, getIt } = require('../utils/mocha')
 const { expectIsBitswap } = require('./utils')
 
-/** @typedef { import("ipfsd-ctl").TestsInterface } TestsInterface */
+/** @typedef { import("ipfsd-ctl/src/factory") } Factory */
 /**
- * @param {TestsInterface} common
+ * @param {Factory} common
  * @param {Object} options
  */
 module.exports = (common, options) => {
@@ -16,15 +16,11 @@ module.exports = (common, options) => {
   describe('.stats.bitswap', () => {
     let ipfs
 
-    before(async function () {
-      // CI takes longer to instantiate the daemon, so we need to increase the
-      // timeout for the before step
-      this.timeout(60 * 1000)
-
-      ipfs = await common.setup()
+    before(async () => {
+      ipfs = (await common.spawn()).api
     })
 
-    after(() => common.teardown())
+    after(() => common.clean())
 
     it('should get bitswap stats', async () => {
       const res = await ipfs.stats.bitswap()

--- a/src/stats/bitswap.js
+++ b/src/stats/bitswap.js
@@ -4,10 +4,14 @@
 const { getDescribe, getIt } = require('../utils/mocha')
 const { expectIsBitswap } = require('./utils')
 
-module.exports = (createCommon, options) => {
+/** @typedef { import("ipfsd-ctl").TestsInterface } TestsInterface */
+/**
+ * @param {TestsInterface} common
+ * @param {Object} options
+ */
+module.exports = (common, options) => {
   const describe = getDescribe(options)
   const it = getIt(options)
-  const common = createCommon()
 
   describe('.stats.bitswap', () => {
     let ipfs

--- a/src/stats/bw-pull-stream.js
+++ b/src/stats/bw-pull-stream.js
@@ -5,10 +5,14 @@ const { expectIsBandwidth } = require('./utils')
 const pullToPromise = require('pull-to-promise')
 const { getDescribe, getIt } = require('../utils/mocha')
 
-module.exports = (createCommon, options) => {
+/** @typedef { import("ipfsd-ctl").TestsInterface } TestsInterface */
+/**
+ * @param {TestsInterface} common
+ * @param {Object} options
+ */
+module.exports = (common, options) => {
   const describe = getDescribe(options)
   const it = getIt(options)
-  const common = createCommon()
 
   describe('.stats.bwPullStream', () => {
     let ipfs

--- a/src/stats/bw-pull-stream.js
+++ b/src/stats/bw-pull-stream.js
@@ -5,9 +5,9 @@ const { expectIsBandwidth } = require('./utils')
 const pullToPromise = require('pull-to-promise')
 const { getDescribe, getIt } = require('../utils/mocha')
 
-/** @typedef { import("ipfsd-ctl").TestsInterface } TestsInterface */
+/** @typedef { import("ipfsd-ctl/src/factory") } Factory */
 /**
- * @param {TestsInterface} common
+ * @param {Factory} common
  * @param {Object} options
  */
 module.exports = (common, options) => {
@@ -17,15 +17,11 @@ module.exports = (common, options) => {
   describe('.stats.bwPullStream', () => {
     let ipfs
 
-    before(async function () {
-      // CI takes longer to instantiate the daemon, so we need to increase the
-      // timeout for the before step
-      this.timeout(60 * 1000)
-
-      ipfs = await common.setup()
+    before(async () => {
+      ipfs = (await common.spawn()).api
     })
 
-    after(() => common.teardown())
+    after(() => common.clean())
 
     it('should get bandwidth stats over pull stream', async () => {
       const stream = ipfs.stats.bwPullStream()

--- a/src/stats/bw-readable-stream.js
+++ b/src/stats/bw-readable-stream.js
@@ -5,10 +5,14 @@ const { expectIsBandwidth } = require('./utils')
 const { getDescribe, getIt } = require('../utils/mocha')
 const getStream = require('get-stream')
 
-module.exports = (createCommon, options) => {
+/** @typedef { import("ipfsd-ctl").TestsInterface } TestsInterface */
+/**
+ * @param {TestsInterface} common
+ * @param {Object} options
+ */
+module.exports = (common, options) => {
   const describe = getDescribe(options)
   const it = getIt(options)
-  const common = createCommon()
 
   describe('.stats.bwReadableStream', () => {
     let ipfs

--- a/src/stats/bw-readable-stream.js
+++ b/src/stats/bw-readable-stream.js
@@ -5,9 +5,9 @@ const { expectIsBandwidth } = require('./utils')
 const { getDescribe, getIt } = require('../utils/mocha')
 const getStream = require('get-stream')
 
-/** @typedef { import("ipfsd-ctl").TestsInterface } TestsInterface */
+/** @typedef { import("ipfsd-ctl/src/factory") } Factory */
 /**
- * @param {TestsInterface} common
+ * @param {Factory} common
  * @param {Object} options
  */
 module.exports = (common, options) => {
@@ -17,15 +17,11 @@ module.exports = (common, options) => {
   describe('.stats.bwReadableStream', () => {
     let ipfs
 
-    before(async function () {
-      // CI takes longer to instantiate the daemon, so we need to increase the
-      // timeout for the before step
-      this.timeout(60 * 1000)
-
-      ipfs = await common.setup()
+    before(async () => {
+      ipfs = (await common.spawn()).api
     })
 
-    after(() => common.teardown())
+    after(() => common.clean())
 
     it('should get bandwidth stats over readable stream', async () => {
       const stream = ipfs.stats.bwReadableStream()

--- a/src/stats/bw.js
+++ b/src/stats/bw.js
@@ -4,9 +4,9 @@
 const { expectIsBandwidth } = require('./utils')
 const { getDescribe, getIt } = require('../utils/mocha')
 
-/** @typedef { import("ipfsd-ctl").TestsInterface } TestsInterface */
+/** @typedef { import("ipfsd-ctl/src/factory") } Factory */
 /**
- * @param {TestsInterface} common
+ * @param {Factory} common
  * @param {Object} options
  */
 module.exports = (common, options) => {
@@ -16,15 +16,11 @@ module.exports = (common, options) => {
   describe('.stats.bw', () => {
     let ipfs
 
-    before(async function () {
-      // CI takes longer to instantiate the daemon, so we need to increase the
-      // timeout for the before step
-      this.timeout(60 * 1000)
-
-      ipfs = await common.setup()
+    before(async () => {
+      ipfs = (await common.spawn()).api
     })
 
-    after(() => common.teardown())
+    after(() => common.clean())
 
     it('should get bandwidth stats ', async () => {
       const res = await ipfs.stats.bw()

--- a/src/stats/bw.js
+++ b/src/stats/bw.js
@@ -4,10 +4,14 @@
 const { expectIsBandwidth } = require('./utils')
 const { getDescribe, getIt } = require('../utils/mocha')
 
-module.exports = (createCommon, options) => {
+/** @typedef { import("ipfsd-ctl").TestsInterface } TestsInterface */
+/**
+ * @param {TestsInterface} common
+ * @param {Object} options
+ */
+module.exports = (common, options) => {
   const describe = getDescribe(options)
   const it = getIt(options)
-  const common = createCommon()
 
   describe('.stats.bw', () => {
     let ipfs

--- a/src/stats/repo.js
+++ b/src/stats/repo.js
@@ -4,10 +4,14 @@
 const { expectIsRepo } = require('./utils')
 const { getDescribe, getIt } = require('../utils/mocha')
 
-module.exports = (createCommon, options) => {
+/** @typedef { import("ipfsd-ctl").TestsInterface } TestsInterface */
+/**
+ * @param {TestsInterface} common
+ * @param {Object} options
+ */
+module.exports = (common, options) => {
   const describe = getDescribe(options)
   const it = getIt(options)
-  const common = createCommon()
 
   describe('.stats.repo', () => {
     let ipfs

--- a/src/stats/repo.js
+++ b/src/stats/repo.js
@@ -4,9 +4,9 @@
 const { expectIsRepo } = require('./utils')
 const { getDescribe, getIt } = require('../utils/mocha')
 
-/** @typedef { import("ipfsd-ctl").TestsInterface } TestsInterface */
+/** @typedef { import("ipfsd-ctl/src/factory") } Factory */
 /**
- * @param {TestsInterface} common
+ * @param {Factory} common
  * @param {Object} options
  */
 module.exports = (common, options) => {
@@ -16,15 +16,11 @@ module.exports = (common, options) => {
   describe('.stats.repo', () => {
     let ipfs
 
-    before(async function () {
-      // CI takes longer to instantiate the daemon, so we need to increase the
-      // timeout for the before step
-      this.timeout(60 * 1000)
-
-      ipfs = await common.setup()
+    before(async () => {
+      ipfs = (await common.spawn()).api
     })
 
-    after(() => common.teardown())
+    after(() => common.clean())
 
     it('should get repo stats', async () => {
       const res = await ipfs.stats.repo()

--- a/src/swarm/addrs.js
+++ b/src/swarm/addrs.js
@@ -4,10 +4,14 @@
 const PeerInfo = require('peer-info')
 const { getDescribe, getIt, expect } = require('../utils/mocha')
 
-module.exports = (createCommon, options) => {
+/** @typedef { import("ipfsd-ctl").TestsInterface } TestsInterface */
+/**
+ * @param {TestsInterface} common
+ * @param {Object} options
+ */
+module.exports = (common, options) => {
   const describe = getDescribe(options)
   const it = getIt(options)
-  const common = createCommon()
 
   describe('.swarm.addrs', function () {
     this.timeout(80 * 1000)

--- a/src/swarm/addrs.js
+++ b/src/swarm/addrs.js
@@ -4,9 +4,9 @@
 const PeerInfo = require('peer-info')
 const { getDescribe, getIt, expect } = require('../utils/mocha')
 
-/** @typedef { import("ipfsd-ctl").TestsInterface } TestsInterface */
+/** @typedef { import("ipfsd-ctl/src/factory") } Factory */
 /**
- * @param {TestsInterface} common
+ * @param {Factory} common
  * @param {Object} options
  */
 module.exports = (common, options) => {
@@ -20,12 +20,12 @@ module.exports = (common, options) => {
     let ipfsB
 
     before(async () => {
-      ipfsA = await common.setup()
-      ipfsB = await common.setup({ type: 'js' })
+      ipfsA = (await common.spawn()).api
+      ipfsB = (await common.spawn({ type: 'js' })).api
       await ipfsA.swarm.connect(ipfsB.peerId.addresses[0])
     })
 
-    after(() => common.teardown())
+    after(() => common.clean())
 
     it('should get a list of node addresses', async () => {
       const peerInfos = await ipfsA.swarm.addrs()

--- a/src/swarm/addrs.js
+++ b/src/swarm/addrs.js
@@ -21,7 +21,7 @@ module.exports = (common, options) => {
 
     before(async () => {
       ipfsA = await common.setup()
-      ipfsB = await common.setup()
+      ipfsB = await common.setup({ type: 'js' })
       await ipfsA.swarm.connect(ipfsB.peerId.addresses[0])
     })
 

--- a/src/swarm/connect.js
+++ b/src/swarm/connect.js
@@ -3,9 +3,9 @@
 
 const { getDescribe, getIt, expect } = require('../utils/mocha')
 
-/** @typedef { import("ipfsd-ctl").TestsInterface } TestsInterface */
+/** @typedef { import("ipfsd-ctl/src/factory") } Factory */
 /**
- * @param {TestsInterface} common
+ * @param {Factory} common
  * @param {Object} options
  */
 module.exports = (common, options) => {
@@ -18,11 +18,11 @@ module.exports = (common, options) => {
     let ipfsB
 
     before(async () => {
-      ipfsA = await common.setup()
-      ipfsB = await common.setup({ type: 'js' })
+      ipfsA = (await common.spawn()).api
+      ipfsB = (await common.spawn({ type: 'js' })).api
     })
 
-    after(() => common.teardown())
+    after(() => common.clean())
 
     it('should connect to a peer', async () => {
       let peers

--- a/src/swarm/connect.js
+++ b/src/swarm/connect.js
@@ -3,10 +3,14 @@
 
 const { getDescribe, getIt, expect } = require('../utils/mocha')
 
-module.exports = (createCommon, options) => {
+/** @typedef { import("ipfsd-ctl").TestsInterface } TestsInterface */
+/**
+ * @param {TestsInterface} common
+ * @param {Object} options
+ */
+module.exports = (common, options) => {
   const describe = getDescribe(options)
   const it = getIt(options)
-  const common = createCommon()
 
   describe('.swarm.connect', function () {
     this.timeout(80 * 1000)

--- a/src/swarm/connect.js
+++ b/src/swarm/connect.js
@@ -19,7 +19,7 @@ module.exports = (common, options) => {
 
     before(async () => {
       ipfsA = await common.setup()
-      ipfsB = await common.setup()
+      ipfsB = await common.setup({ type: 'js' })
     })
 
     after(() => common.teardown())

--- a/src/swarm/disconnect.js
+++ b/src/swarm/disconnect.js
@@ -3,10 +3,14 @@
 
 const { getDescribe, getIt, expect } = require('../utils/mocha')
 
-module.exports = (createCommon, options) => {
+/** @typedef { import("ipfsd-ctl").TestsInterface } TestsInterface */
+/**
+ * @param {TestsInterface} common
+ * @param {Object} options
+ */
+module.exports = (common, options) => {
   const describe = getDescribe(options)
   const it = getIt(options)
-  const common = createCommon()
 
   describe('.swarm.disconnect', function () {
     this.timeout(80 * 1000)

--- a/src/swarm/disconnect.js
+++ b/src/swarm/disconnect.js
@@ -20,7 +20,7 @@ module.exports = (common, options) => {
 
     before(async () => {
       ipfsA = await common.setup()
-      ipfsB = await common.setup()
+      ipfsB = await common.setup({ type: 'js' })
       await ipfsA.swarm.connect(ipfsB.peerId.addresses[0])
     })
 

--- a/src/swarm/disconnect.js
+++ b/src/swarm/disconnect.js
@@ -3,9 +3,9 @@
 
 const { getDescribe, getIt, expect } = require('../utils/mocha')
 
-/** @typedef { import("ipfsd-ctl").TestsInterface } TestsInterface */
+/** @typedef { import("ipfsd-ctl/src/factory") } Factory */
 /**
- * @param {TestsInterface} common
+ * @param {Factory} common
  * @param {Object} options
  */
 module.exports = (common, options) => {
@@ -19,12 +19,12 @@ module.exports = (common, options) => {
     let ipfsB
 
     before(async () => {
-      ipfsA = await common.setup()
-      ipfsB = await common.setup({ type: 'js' })
+      ipfsA = (await common.spawn()).api
+      ipfsB = (await common.spawn({ type: 'js' })).api
       await ipfsA.swarm.connect(ipfsB.peerId.addresses[0])
     })
 
-    after(() => common.teardown())
+    after(() => common.clean())
 
     it('should disconnect from a peer', async () => {
       let peers

--- a/src/swarm/local-addrs.js
+++ b/src/swarm/local-addrs.js
@@ -3,9 +3,9 @@
 
 const { getDescribe, getIt, expect } = require('../utils/mocha')
 
-/** @typedef { import("ipfsd-ctl").TestsInterface } TestsInterface */
+/** @typedef { import("ipfsd-ctl/src/factory") } Factory */
 /**
- * @param {TestsInterface} common
+ * @param {Factory} common
  * @param {Object} options
  */
 module.exports = (common, options) => {
@@ -18,10 +18,10 @@ module.exports = (common, options) => {
     let ipfs
 
     before(async () => {
-      ipfs = await common.setup()
+      ipfs = (await common.spawn()).api
     })
 
-    after(() => common.teardown())
+    after(() => common.clean())
 
     it('should list local addresses the node is listening on', async () => {
       const multiaddrs = await ipfs.swarm.localAddrs()

--- a/src/swarm/local-addrs.js
+++ b/src/swarm/local-addrs.js
@@ -3,10 +3,14 @@
 
 const { getDescribe, getIt, expect } = require('../utils/mocha')
 
-module.exports = (createCommon, options) => {
+/** @typedef { import("ipfsd-ctl").TestsInterface } TestsInterface */
+/**
+ * @param {TestsInterface} common
+ * @param {Object} options
+ */
+module.exports = (common, options) => {
   const describe = getDescribe(options)
   const it = getIt(options)
-  const common = createCommon()
 
   describe('.swarm.localAddrs', function () {
     this.timeout(80 * 1000)

--- a/src/swarm/peers.js
+++ b/src/swarm/peers.js
@@ -23,7 +23,7 @@ module.exports = (common, options) => {
 
     before(async () => {
       ipfsA = await common.setup()
-      ipfsB = await common.setup()
+      ipfsB = await common.setup({ type: 'js' })
       await ipfsA.swarm.connect(ipfsB.peerId.addresses[0])
       await delay(60 * 1000) // wait for open streams in the connection available
     })
@@ -84,10 +84,8 @@ module.exports = (common, options) => {
     }
 
     it('should list peers only once', async () => {
-      const config = getConfig(['/ip4/127.0.0.1/tcp/0'])
-
-      const nodeA = await common.setup({ spawnOptions: { config } })
-      const nodeB = await common.setup({ spawnOptions: { config } })
+      const nodeA = await common.setup()
+      const nodeB = await common.setup({ type: 'js' })
       await nodeA.swarm.connect(nodeB.peerId.addresses[0])
       await delay(1000)
       const peersA = await nodeA.swarm.peers()
@@ -103,11 +101,11 @@ module.exports = (common, options) => {
         '/ip4/127.0.0.1/tcp/16544'
       ])
       const configB = getConfig([
-        '/ip4/127.0.0.1/tcp/26545',
-        '/ip4/127.0.0.1/tcp/26546'
+        '/ip4/127.0.0.1/tcp/26545/ws',
+        '/ip4/127.0.0.1/tcp/26546/ws'
       ])
-      const nodeA = await common.setup({ spawnOptions: { config: configA } })
-      const nodeB = await common.setup({ spawnOptions: { config: configB } })
+      const nodeA = await common.setup({ ipfsOptions: { config: configA } })
+      const nodeB = await common.setup({ type: 'js', ipfsOptions: { config: configB } })
       await nodeA.swarm.connect(nodeB.peerId.addresses[0])
       await delay(1000)
       const peersA = await nodeA.swarm.peers()

--- a/src/swarm/peers.js
+++ b/src/swarm/peers.js
@@ -6,10 +6,14 @@ const PeerId = require('peer-id')
 const delay = require('delay')
 const { getDescribe, getIt, expect } = require('../utils/mocha')
 
-module.exports = (createCommon, options) => {
+/** @typedef { import("ipfsd-ctl").TestsInterface } TestsInterface */
+/**
+ * @param {TestsInterface} common
+ * @param {Object} options
+ */
+module.exports = (common, options) => {
   const describe = getDescribe(options)
   const it = getIt(options)
-  const common = createCommon()
 
   describe('.swarm.peers', function () {
     this.timeout(80 * 1000)

--- a/src/swarm/peers.js
+++ b/src/swarm/peers.js
@@ -23,7 +23,7 @@ module.exports = (common, options) => {
 
     before(async () => {
       ipfsA = await common.setup()
-      ipfsB = await common.setup({ type: 'js' })
+      ipfsB = await common.setup({ type: 'go' })
       await ipfsA.swarm.connect(ipfsB.peerId.addresses[0])
       await delay(60 * 1000) // wait for open streams in the connection available
     })
@@ -85,7 +85,7 @@ module.exports = (common, options) => {
 
     it('should list peers only once', async () => {
       const nodeA = await common.setup()
-      const nodeB = await common.setup({ type: 'js' })
+      const nodeB = await common.setup({ type: 'go' })
       await nodeA.swarm.connect(nodeB.peerId.addresses[0])
       await delay(1000)
       const peersA = await nodeA.swarm.peers()
@@ -105,7 +105,7 @@ module.exports = (common, options) => {
         '/ip4/127.0.0.1/tcp/26546/ws'
       ])
       const nodeA = await common.setup({ ipfsOptions: { config: configA } })
-      const nodeB = await common.setup({ type: 'js', ipfsOptions: { config: configB } })
+      const nodeB = await common.setup({ type: 'go', ipfsOptions: { config: configB } })
       await nodeA.swarm.connect(nodeB.peerId.addresses[0])
       await delay(1000)
       const peersA = await nodeA.swarm.peers()


### PR DESCRIPTION
Uses a new simpler and async tests setup and also makes use of the new jsdoc typedefs so we get code completion in this repo when writing new tests.

needs:

- [x] https://github.com/ipfs/js-ipfsd-ctl/pull/395