### PR TITLE
Add dht.provide() test with string CID parameter

### DIFF
--- a/src/dht/provide.js
+++ b/src/dht/provide.js
@@ -88,7 +88,18 @@ module.exports = (createCommon, options) => {
         })
       })
     })
+    it('should provide a CIDv1 string', (done) => {
+      ipfs.add(Buffer.from('test'), { cidVersion: 1 }, (err, res) => {
+        if (err) return done(err)
 
+        const cid = res[0].hash
+
+        ipfs.dht.provide(cid, (err) => {
+          expect(err).to.not.exist()
+          done()
+        })
+      })
+    })
     it('should error on non CID arg', (done) => {
       ipfs.dht.provide({}, (err) => {
         expect(err).to.exist()


### PR DESCRIPTION
This is in reference to https://github.com/ipfs/js-ipfs/pull/2589
Tests that dht.provide() works with a CID string