### PR TITLE
fix: handle err on both start and stop echo-server

### DIFF
--- a/src/utils/echo-http-server.js
+++ b/src/utils/echo-http-server.js
@@ -44,10 +44,12 @@ module.exports.createServer = () => {
   const server = http.createServer(handler)
 
   server.start = (opts) => new Promise(
-    (resolve) => server.listen(Object.assign({ port: defaultPort, host: '127.0.0.1' }, opts), resolve)
+    (resolve, reject) => server.listen(
+      Object.assign({ port: defaultPort, host: '127.0.0.1' }, opts), (err) => err ? reject(err) : resolve()
+    )
   )
 
-  server.stop = () => new Promise((resolve) => server.close(resolve))
+  server.stop = () => new Promise((resolve, reject) => server.close((err) => err ? reject(err) : resolve()))
 
   return server
 }

--- a/src/utils/echo-http-server.js
+++ b/src/utils/echo-http-server.js
@@ -53,9 +53,9 @@ module.exports.createServer = () => {
 
   server.stop = () => new Promise((resolve, reject) => {
     server.once('error', reject)
-    server.close(() => {
+    server.close((err) => {
       server.removeListener('error', reject)
-      resolve()
+      err ? reject(err) : resolve()
     })
   })
 

--- a/src/utils/echo-http-server.js
+++ b/src/utils/echo-http-server.js
@@ -43,13 +43,21 @@ module.exports.createServer = () => {
 
   const server = http.createServer(handler)
 
-  server.start = (opts) => new Promise(
-    (resolve, reject) => server.listen(
-      Object.assign({ port: defaultPort, host: '127.0.0.1' }, opts), (err) => err ? reject(err) : resolve()
-    )
-  )
+  server.start = (opts) => new Promise((resolve, reject) => {
+    server.once('error', reject)
+    server.listen(Object.assign({ port: defaultPort, host: '127.0.0.1' }, opts), () => {
+      server.removeListener('error', reject)
+      resolve()
+    })
+  })
 
-  server.stop = () => new Promise((resolve, reject) => server.close((err) => err ? reject(err) : resolve()))
+  server.stop = () => new Promise((resolve, reject) => {
+    server.once('error', reject)
+    server.close(() => {
+      server.removeListener('error', reject)
+      resolve()
+    })
+  })
 
   return server
 }


### PR DESCRIPTION
`echo-server` was not handling properly error on both `start()` and `stop()` methods. 

@achingbrain suggested on https://github.com/ipfs/interface-js-ipfs-core/pull/565 's [review](https://github.com/ipfs/interface-js-ipfs-core/pull/565/files#r352515503):

```javascript
server.start = (opts) => new Promise((resolve, reject) => {
  server.once('error', reject)
  server.listen(Object.assign({ port: defaultPort, host: '127.0.0.1' }, opts), () => {
    server.removeListener('error', reject)
    resolve()
  })
})
```

I think we just want to check `server.listen()` and `server.close()` related errors. For this reason, my suggestion is:

```javascript
server.start = (opts) => new Promise(
  (resolve, reject) => server.listen(
    Object.assign({ port: defaultPort, host: '127.0.0.1' }, opts), (err) => err ? reject(err) : resolve()
  )
)
```
