### PR TITLE
docs: update files.flush return type

### DIFF
--- a/SPEC/FILES.md
+++ b/SPEC/FILES.md
@@ -1204,22 +1204,22 @@ await ipfs.files.mv('/src-file1', '/src-file2', '/dst-dir')
 
 > Flush a given path's data to the disk
 
-##### `ipfs.files.flush([...paths])`
+##### `ipfs.files.flush([path])`
 
 Where:
 
-- `paths` are optional string paths to flush (default: `/`)
+- `path` is an optional string path to flush (default: `/`)
 
 **Returns**
 
 | Type | Description |
 | -------- | -------- |
-| `Promise<void>` | If successfully copied. Otherwise an error will be thrown |
+| `Promise<CID>` | The CID of the path that has been flushed |
 
 **Example:**
 
 ```JavaScript
-await ipfs.files.flush('/')
+const cid = await ipfs.files.flush('/')
 ```
 
 #### `files.ls`

--- a/src/files-mfs/flush.js
+++ b/src/files-mfs/flush.js
@@ -13,7 +13,7 @@ module.exports = (common, options) => {
   const describe = getDescribe(options)
   const it = getIt(options)
 
-  describe('.files.flush', function () {
+  describe.only('.files.flush', function () {
     this.timeout(40 * 1000)
 
     let ipfs
@@ -32,13 +32,22 @@ module.exports = (common, options) => {
       }
     })
 
-    it('should flush root', () => ipfs.files.flush())
+    it('should flush root', async () => {
+      const root = await ipfs.files.stat('/')
+      const flushed = await ipfs.files.flush()
+
+      expect(root.hash).to.equal(flushed.toString())
+    })
 
     it('should flush specific dir', async () => {
       const testDir = `/test-${hat()}`
 
       await ipfs.files.mkdir(testDir, { parents: true })
-      await ipfs.files.flush(testDir)
+
+      const dirStats = await ipfs.files.stat(testDir)
+      const flushed = await ipfs.files.flush(testDir)
+
+      expect(dirStats.hash).to.equal(flushed.toString())
     })
   })
 }

--- a/src/files-mfs/flush.js
+++ b/src/files-mfs/flush.js
@@ -13,7 +13,7 @@ module.exports = (common, options) => {
   const describe = getDescribe(options)
   const it = getIt(options)
 
-  describe.only('.files.flush', function () {
+  describe('.files.flush', function () {
     this.timeout(40 * 1000)
 
     let ipfs


### PR DESCRIPTION
`ipfs.files.flush` returns the CID of the flushed path since [`go-IPFS@v0.4.20`](https://github.com/ipfs/go-ipfs/pull/6223/files#diff-4ac32a78649ca5bdd8e0ba38b7006a1eR141).

It also only takes one path as an optional parameter.