### PR TITLE
fix: do not assume certain implementations of ipfs are present

### DIFF
--- a/src/bitswap/wantlist.js
+++ b/src/bitswap/wantlist.js
@@ -21,7 +21,7 @@ module.exports = (common, options) => {
 
     before(async () => {
       ipfsA = (await common.spawn()).api
-      ipfsB = (await common.spawn({ type: 'go' })).api
+      ipfsB = (await common.spawn()).api
       // Add key to the wantlist for ipfsB
       ipfsB.block.get(key).catch(() => { /* is ok, expected on teardown */ })
       await ipfsA.swarm.connect(ipfsB.peerId.addresses[0])

--- a/src/miscellaneous/resolve.js
+++ b/src/miscellaneous/resolve.js
@@ -82,7 +82,7 @@ module.exports = (common, options) => {
 
     it('should resolve IPNS link recursively', async function () {
       this.timeout(20 * 1000)
-      const node = (await common.spawn({ type: 'go' })).api
+      const node = (await common.spawn()).api
       await ipfs.swarm.connect(node.peerId.addresses[0])
       const [{ path }] = await all(ipfs.add(Buffer.from('should resolve a record recursive === true')))
       const { id: keyId } = await ipfs.key.gen('key-name', { type: 'rsa', size: 2048 })

--- a/src/ping/ping.js
+++ b/src/ping/ping.js
@@ -22,7 +22,7 @@ module.exports = (common, options) => {
 
     before(async () => {
       ipfsA = (await common.spawn()).api
-      ipfsB = (await common.spawn({ type: 'js' })).api
+      ipfsB = (await common.spawn()).api
       await ipfsA.swarm.connect(ipfsB.peerId.addresses[0])
     })
 

--- a/src/pubsub/peers.js
+++ b/src/pubsub/peers.js
@@ -23,8 +23,8 @@ module.exports = (common, options) => {
     let subscribedTopics = []
     before(async () => {
       ipfs1 = (await common.spawn()).api
-      ipfs2 = (await common.spawn({ type: 'go' })).api
-      ipfs3 = (await common.spawn({ type: 'go' })).api
+      ipfs2 = (await common.spawn()).api
+      ipfs3 = (await common.spawn()).api
 
       const ipfs2Addr = ipfs2.peerId.addresses
         .find(ma => ma.nodeAddress().address === '127.0.0.1')

--- a/src/pubsub/subscribe.js
+++ b/src/pubsub/subscribe.js
@@ -28,7 +28,7 @@ module.exports = (common, options) => {
       ipfs1 = (await common.spawn()).api
       // TODO 'multiple connected nodes' tests fails with go in Firefox
       // and JS is flaky everywhere
-      ipfs2 = (await common.spawn({ type: 'go' })).api
+      ipfs2 = (await common.spawn()).api
     })
 
     beforeEach(() => {

--- a/src/swarm/addrs.js
+++ b/src/swarm/addrs.js
@@ -22,7 +22,7 @@ module.exports = (common, options) => {
 
     before(async () => {
       ipfsA = (await common.spawn()).api
-      ipfsB = (await common.spawn({ type: 'js' })).api
+      ipfsB = (await common.spawn()).api
       await ipfsA.swarm.connect(ipfsB.peerId.addresses[0])
     })
 

--- a/src/swarm/connect.js
+++ b/src/swarm/connect.js
@@ -19,7 +19,7 @@ module.exports = (common, options) => {
 
     before(async () => {
       ipfsA = (await common.spawn()).api
-      ipfsB = (await common.spawn({ type: 'js' })).api
+      ipfsB = (await common.spawn()).api
     })
 
     after(() => common.clean())

--- a/src/swarm/disconnect.js
+++ b/src/swarm/disconnect.js
@@ -20,7 +20,7 @@ module.exports = (common, options) => {
 
     before(async () => {
       ipfsA = (await common.spawn()).api
-      ipfsB = (await common.spawn({ type: 'js' })).api
+      ipfsB = (await common.spawn()).api
       await ipfsA.swarm.connect(ipfsB.peerId.addresses[0])
     })
 

--- a/src/swarm/peers.js
+++ b/src/swarm/peers.js
@@ -99,18 +99,18 @@ module.exports = (common, options) => {
 
     it('should list peers only once even if they have multiple addresses', async () => {
       // TODO: Change to port 0, needs: https://github.com/ipfs/interface-ipfs-core/issues/152
-      const configA = getConfig(isNode ? [
+      const configA = getConfig(isNode || (common.opts && common.opts.type === 'go') ? [
         '/ip4/127.0.0.1/tcp/16543',
         '/ip4/127.0.0.1/tcp/16544'
       ] : [
-        '/ip4/127.0.0.1/tcp/14579/wss/p2p-webrtc-star',
+        '/ip4/127.0.0.1/tcp/14578/wss/p2p-webrtc-star',
         '/ip4/127.0.0.1/tcp/14579/wss/p2p-webrtc-star'
       ])
-      const configB = getConfig(isNode ? [
+      const configB = getConfig(isNode || (common.opts && common.opts.type === 'go') ? [
         '/ip4/127.0.0.1/tcp/26545/ws',
         '/ip4/127.0.0.1/tcp/26546/ws'
       ] : [
-        '/ip4/127.0.0.1/tcp/14579/wss/p2p-webrtc-star',
+        '/ip4/127.0.0.1/tcp/14578/wss/p2p-webrtc-star',
         '/ip4/127.0.0.1/tcp/14579/wss/p2p-webrtc-star'
       ])
       const nodeA = (await common.spawn({ ipfsOptions: { config: configA } })).api

--- a/src/swarm/peers.js
+++ b/src/swarm/peers.js
@@ -24,7 +24,7 @@ module.exports = (common, options) => {
 
     before(async () => {
       ipfsA = (await common.spawn()).api
-      ipfsB = (await common.spawn({ type: 'go' })).api
+      ipfsB = (await common.spawn()).api
       await ipfsA.swarm.connect(ipfsB.peerId.addresses[0])
       /* TODO: Seen if we still need this after this is fixed
          https://github.com/ipfs/js-ipfs/issues/2601 gets resolved */
@@ -88,7 +88,7 @@ module.exports = (common, options) => {
 
     it('should list peers only once', async () => {
       const nodeA = (await common.spawn()).api
-      const nodeB = (await common.spawn({ type: 'go' })).api
+      const nodeB = (await common.spawn()).api
       await nodeA.swarm.connect(nodeB.peerId.addresses[0])
       await delay(1000)
       const peersA = await nodeA.swarm.peers()

--- a/src/swarm/peers.js
+++ b/src/swarm/peers.js
@@ -108,7 +108,7 @@ module.exports = (common, options) => {
         '/ip4/127.0.0.1/tcp/26546/ws'
       ])
       const nodeA = (await common.spawn({ ipfsOptions: { config: configA } })).api
-      const nodeB = (await common.spawn({ type: 'js', ipfsOptions: { config: configB } })).api
+      const nodeB = (await common.spawn({ ipfsOptions: { config: configB } })).api
       await nodeA.swarm.connect(nodeB.peerId.addresses[0])
       await delay(1000)
       const peersA = await nodeA.swarm.peers()

--- a/src/swarm/peers.js
+++ b/src/swarm/peers.js
@@ -99,13 +99,19 @@ module.exports = (common, options) => {
 
     it('should list peers only once even if they have multiple addresses', async () => {
       // TODO: Change to port 0, needs: https://github.com/ipfs/interface-ipfs-core/issues/152
-      const configA = getConfig(isNode ? [ // browser nodes cannot listen
+      const configA = getConfig(isNode ? [
         '/ip4/127.0.0.1/tcp/16543',
         '/ip4/127.0.0.1/tcp/16544'
-      ] : [])
-      const configB = getConfig([
+      ] : [
+        '/ip4/127.0.0.1/tcp/14579/wss/p2p-webrtc-star',
+        '/ip4/127.0.0.1/tcp/14579/wss/p2p-webrtc-star'
+      ])
+      const configB = getConfig(isNode ? [
         '/ip4/127.0.0.1/tcp/26545/ws',
         '/ip4/127.0.0.1/tcp/26546/ws'
+      ] : [
+        '/ip4/127.0.0.1/tcp/14579/wss/p2p-webrtc-star',
+        '/ip4/127.0.0.1/tcp/14579/wss/p2p-webrtc-star'
       ])
       const nodeA = (await common.spawn({ ipfsOptions: { config: configA } })).api
       const nodeB = (await common.spawn({ ipfsOptions: { config: configB } })).api


### PR DESCRIPTION
Passing `type: 'js'` requires the containing project to have a dependency on js-IPFS which may not be the case.

I don't think anything in these tests requires the js implementation.  Please do shout if something does.